### PR TITLE
VM OpCodes implementation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Octavian Once <octavonce@gmail.com>
+Marius Todoran <itodoranmarius@gmail.com>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,14 +110,14 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x6e` Nip - Removes the second item on the stack
     - [ ] OP `0x6f` Over - Duplicates the second item on the stack
     - [x] OP `0x70` Pick - Duplicates the `n`th item on the stack
-    - [ ] OP `0x71` Roll - The `n`th item on the stack is moved to the top
+    - [x] OP `0x71` Roll - The `n`th item on the stack is moved to the top
     - [ ] OP `0x72` Rot - The three topmost items on the stack are rotated to the left
-    - [ ] OP `0x73` Swap - The two topmost items on the stack are swaped
-    - [ ] OP `0x74` Tuck - The topmost item on the stack is copied and inserted before the second-to-top item
-    - [ ] OP `0x75` Drop2 - Removes the first two topmost items on the stack
-    - [ ] OP `0x76` Dup2 - Duplicates the first two topmost items on the stack
-    - [ ] OP `0x77` Dup3 - Duplicates the first three topmost items on the stack
-    - [ ] OP `0x78` Over2 - Duplicates the second and third items on the stack
+    - [x] OP `0x73` Swap - The two topmost items on the stack are swaped
+    - [x] OP `0x74` Tuck - The topmost item on the stack is copied and inserted before the second-to-top item
+    - [x] OP `0x75` Drop2 - Removes the first two topmost items on the stack
+    - [x] OP `0x76` Dup2 - Duplicates the first two topmost items on the stack
+    - [x] OP `0x77` Dup3 - Duplicates the first three topmost items on the stack
+    - [x] OP `0x78` Over2 - Duplicates the second and third items on the stack
     - [ ] OP `0x79` Rot2 - The fifth and sixth topmost items on the stack are moved to the top
     - [ ] OP `0x7a` Swap2 - Swaps the topmost pairs of terms on top of the stack
     - [ ] OP `0x7b` Size - Pushes the size in bytes of the topmost item on the stack

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,7 +127,7 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x80` IsUTF8 - Pushes `1` on top of the stack if the given `Unsigned8Array` is a valid UTF8 byte sequence
     - [x] OP `0x82` Add1 - Adds `1` to the topmost item on the stack
     - [x] OP `0x83` Sub1 - Subtracts `1` from the topmost item on the stack
-    - [ ] OP `0x84` Min - Returns the minimum of the two topmost items on the stack 1 2 -> 1
+    - [ ] OP `0x84` Min - Returns the minimum of the two topmost items on the stack
     - [ ] OP `0x85` Max - Returns the maximum of the two topmost items on the stack
     - [ ] OP `0x86` Within - Pushes `1` on top of the stack if the topmost item on the stack is between the second and the third.
     - [ ] OP `0x87` BoolAnd - And control operator

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,10 +105,10 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x69` ContinueIfGt - Moves to the next iteration of the current loop if the topmost item on the stack is greater than the second
     - [ ] OP `0x6a` Depth - Pushes the depth of the current frame onto the stack as an `Unsigned16`
     - [ ] OP `0x6b` IfDup - If the topmost item on the stack is not `0`, duplicate it
-    - [ ] OP `0x6c` Drop - Removes the topmost item on the stack
-    - [ ] OP `0x6d` Dup - Duplicates the topmost item on the stack
-    - [ ] OP `0x6e` Nip - Removes the second item on the stack
-    - [ ] OP `0x6f` Over - Duplicates the second item on the stack
+    - [x] OP `0x6c` Drop - Removes the topmost item on the stack
+    - [x] OP `0x6d` Dup - Duplicates the topmost item on the stack
+    - [x] OP `0x6e` Nip - Removes the second item on the stack
+    - [x] OP `0x6f` Over - Duplicates the second item on the stack
     - [x] OP `0x70` Pick - Duplicates the `n`th item on the stack
     - [x] OP `0x71` Roll - The `n`th item on the stack is moved to the top
     - [ ] OP `0x72` Rot - The three topmost items on the stack are rotated to the left
@@ -117,7 +117,7 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [x] OP `0x75` Drop2 - Removes the first two topmost items on the stack
     - [x] OP `0x76` Dup2 - Duplicates the first two topmost items on the stack
     - [x] OP `0x77` Dup3 - Duplicates the first three topmost items on the stack
-    - [x] OP `0x78` Over2 - Duplicates the second and third items on the stack
+    - [x] OP `0x78` Over2 - Duplicates the third and fourth items on the stack
     - [ ] OP `0x79` Rot2 - The fifth and sixth topmost items on the stack are moved to the top
     - [ ] OP `0x7a` Swap2 - Swaps the topmost pairs of terms on top of the stack
     - [ ] OP `0x7b` Size - Pushes the size in bytes of the topmost item on the stack
@@ -126,8 +126,8 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x7e` BitInvert - Inverts all bits of the topmost item on the stack
     - [ ] OP `0x80` IsUTF8 - Pushes `1` on top of the stack if the given `Unsigned8Array` is a valid UTF8 byte sequence
     - [x] OP `0x82` Add1 - Adds `1` to the topmost item on the stack
-    - [ ] OP `0x83` Sub1 - Subtracts `1` from the topmost item on the stack
-    - [ ] OP `0x84` Min - Returns the minimum of the two topmost items on the stack
+    - [x] OP `0x83` Sub1 - Subtracts `1` from the topmost item on the stack
+    - [ ] OP `0x84` Min - Returns the minimum of the two topmost items on the stack 1 2 -> 1
     - [ ] OP `0x85` Max - Returns the maximum of the two topmost items on the stack
     - [ ] OP `0x86` Within - Pushes `1` on top of the stack if the topmost item on the stack is between the second and the third.
     - [ ] OP `0x87` BoolAnd - And control operator
@@ -138,8 +138,8 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x8c` PushPrevScriptOutsLen - Pushes the length of previous spend script outs on top of the stack
     - [ ] OP `0x8e` PushExecCount - Pushes the current amount of opcodes that have been executed to the top of the stack
     - [ ] OP `0x8f` FlushToScriptOuts - Flushes the terms on the current frame to the script outputs stack
-    - [ ] OP `0x90` PopToScriptOuts - Pops the topmost item on the stack and pushes it to the script outputs stack
-    - [ ] OP `0x91` PickToScriptOuts - Duplicates the `n`th item on the stack and pushes it to the script outputs stack
+    - [x] OP `0x90` PopToScriptOuts - Pops the topmost item on the stack and pushes it to the script outputs stack
+    - [x] OP `0x91` PickToScriptOuts - Duplicates the `n`th item on the stack and pushes it to the script outputs stack
     - [ ] OP `0x9a` ToHex - Converts the topmost item on the stack to hexadecimal
     - [ ] OP `0x9b` FromHex - Parses the topmost item on the stack from hexadecimal
     - [ ] OP `0xae` CallBody - Interprets the top `Unsigned8Array` on the stack as a Func body and executes it

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,10 +86,10 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x56` BitXOR - Pops the two topmost items on the stack, performs bit exclusive OR on the operands and then pushes the result on the stack
     - [x] OP `0x57` Loop - Starts a loop block
     - [x] OP `0x58` Break - Breaks the current loop
-    - [ ] OP `0x59` BreakIf - Breaks the current loop if the topmost item on the stack is `1`
-    - [ ] OP `0x5a` BreakIfn - Breaks the current loop if the topmost item on the stack is not equal to `1`
+    - [x] OP `0x59` BreakIf - Breaks the current loop if the topmost item on the stack is `1`
+    - [x] OP `0x5a` BreakIfn - Breaks the current loop if the topmost item on the stack is not equal to `1`
     - [x] OP `0x5b` BreakIfEq - Breaks the current loop if the two topmost items on the stack are equal
-    - [ ] OP `0x5c` BreakIfNeq - Breaks the current loop if the two topmost items on the stack are not equal
+    - [x] OP `0x5c` BreakIfNeq - Breaks the current loop if the two topmost items on the stack are not equal
     - [ ] OP `0x5d` BreakIfLeq - Breaks the current loop if the topmost item on the stack is less or equal than the second
     - [ ] OP `0x5e` BreakIfGeq - Breaks the current loop if the topmost item on the stack is greater or equal than the second
     - [ ] OP `0x5f` BreakIfLt - Breaks the current loop if the topmost item on the stack is less than the second
@@ -112,7 +112,7 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [x] OP `0x70` Pick - Duplicates the `n`th item on the stack
     - [ ] OP `0x71` Roll - The `n`th item on the stack is moved to the top
     - [ ] OP `0x72` Rot - The three topmost items on the stack are rotated to the left
-    - [ ] OP `0x73` Swap - The twop topmost items on the stack are swaped
+    - [ ] OP `0x73` Swap - The two topmost items on the stack are swaped
     - [ ] OP `0x74` Tuck - The topmost item on the stack is copied and inserted before the second-to-top item
     - [ ] OP `0x75` Drop2 - Removes the first two topmost items on the stack
     - [ ] OP `0x76` Dup2 - Duplicates the first two topmost items on the stack

--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -94,8 +94,7 @@ pub fn transaction_batch_benchmark(c: &mut Criterion) {
 
         group.bench_function(
             &format!(
-                "verify membership batch all shards in a single sector 100% cache hit rate {}",
-                batch_size
+                "verify membership batch all shards in a single sector 100% cache hit rate {batch_size}"
             ),
             |b| {
                 b.iter(|| {
@@ -113,8 +112,7 @@ pub fn transaction_batch_benchmark(c: &mut Criterion) {
 
         group.bench_function(
             &format!(
-                "verify membership batch all shards in a single sector 95% cache hit rate {}",
-                batch_size
+                "verify membership batch all shards in a single sector 95% cache hit rate {batch_size}"
             ),
             |b| {
                 b.iter(|| {
@@ -132,10 +130,7 @@ pub fn transaction_batch_benchmark(c: &mut Criterion) {
         accumulator::hash::clear_cache();
 
         group.bench_function(
-            &format!(
-                "verify membership batch all shards in a single sector uncached {}",
-                batch_size
-            ),
+            &format!("verify membership batch all shards in a single sector uncached {batch_size}"),
             |b| {
                 b.iter(|| {
                     accumulators_with_proofs
@@ -203,7 +198,7 @@ pub fn transaction_batch_benchmark(c: &mut Criterion) {
         let (_accumulator2, _pa) = witness_deleted.add_with_proof(&out_hashes);
 
         group.bench_function(
-            &format!("mutate accumulators for all shards in sector 100% cache hit rate {} half added and half deleted", batch_size),
+            &format!("mutate accumulators for all shards in sector 100% cache hit rate {batch_size} half added and half deleted"),
             |b| {
                 b.iter(|| {
                     (0..(SHARDS_PER_SECTOR*ACCUMULATOR_MULTIPLIER))

--- a/benches/vm.rs
+++ b/benches/vm.rs
@@ -61,7 +61,7 @@ fn bench_coinbase(c: &mut Criterion) {
         let in_clone = input.clone();
         let inputs = vec![in_clone];
         let inputs: Vec<_> = inputs.iter().cycle().take(b).collect();
-        c.bench_function(&format!("verify coinbase script batch {}", b), |b| {
+        c.bench_function(&format!("verify coinbase script batch {b}"), |b| {
             b.iter(|| {
                 inputs
                     .par_iter()
@@ -87,7 +87,7 @@ fn bench_coinbase(c: &mut Criterion) {
         let inputs = vec![in_clone];
         let inputs: Vec<_> = inputs.iter().cycle().take(b).collect();
         c.bench_function(
-            &format!("verify coinbase script batch all shards {}", b),
+            &format!("verify coinbase script batch all shards {b}"),
             |b| {
                 b.iter(|| {
                     inputs
@@ -160,7 +160,7 @@ fn bench_vm_abuse(c: &mut Criterion) {
     let batch_sizes = vec![100, 500, 1000, 1500, 2000];
 
     for batch_size in batch_sizes {
-        c.bench_function(&format!("abuse vm {} out of gas inputs", batch_size), |b| {
+        c.bench_function(&format!("abuse vm {batch_size} out of gas inputs"), |b| {
             b.iter(|| {
                 (0..batch_size).into_par_iter().for_each(|_| {
                     let mut outs = vec![];

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,6 @@ const HOST_FAMILY: &str = "unix";
 fn main() {
     #[cfg(any(windows, unix))]
     {
-        println!("cargo:rust-cfg=host_family={}", HOST_FAMILY);
+        println!("cargo:rust-cfg=host_family={HOST_FAMILY}");
     }
 }

--- a/src/chain/backend/mod.rs
+++ b/src/chain/backend/mod.rs
@@ -502,13 +502,13 @@ pub fn create_rocksdb_backend<'a>() -> Arc<DB> {
 pub fn read_bitmap(db: Arc<DB>, key: &str) -> Result<Option<Bitmap>, String> {
     db.get(key)
         .map(|res| res.map(|bytes| Bitmap::deserialize(&bytes)))
-        .map_err(|err| format!("could not read bitmap: {}", err))
+        .map_err(|err| format!("could not read bitmap: {err}"))
 }
 
 /// Write bitmap to the database using the provided key
 pub fn write_bitmap(db: Arc<DB>, key: &str, bitmap: Bitmap) -> Result<(), String> {
     db.put(key, bitmap.serialize())
-        .map_err(|err| format!("could not write bitmap: {}", err))
+        .map_err(|err| format!("could not write bitmap: {err}"))
 }
 
 #[derive(Debug, Clone, Encode, Decode)]

--- a/src/chain/chain_config.rs
+++ b/src/chain/chain_config.rs
@@ -27,13 +27,13 @@ impl ChainConfig {
         let mut sector_keys = HashMap::with_capacity(4);
 
         for i in 0..=255 {
-            chain_keys.insert(i, format!("{}.shard.{}", network_name, i));
+            chain_keys.insert(i, format!("{network_name}.shard.{i}"));
         }
 
         let range_e = 256 / SHARDS_PER_SECTOR;
 
         for i in 0..range_e {
-            sector_keys.insert(i as u8, format!("{}.sector.{}", network_name, i));
+            sector_keys.insert(i as u8, format!("{network_name}.sector.{i}"));
         }
 
         Self {

--- a/src/chain/mmr/mod.rs
+++ b/src/chain/mmr/mod.rs
@@ -239,19 +239,18 @@ pub trait MMRBackend<T: Encode> {
     fn merkle_proof(&self, pos0: u64) -> Result<MMRMerkleProof, MMRBackendErr> {
         let size = self.unpruned_size();
         #[cfg(debug_assertions)]
-        println!("merkle_proof  {}, size {}", pos0, size);
+        println!("merkle_proof  {pos0}, size {size}");
 
         // check this pos is actually a leaf in the MMR
         if !is_leaf(pos0) {
             return Err(MMRBackendErr::CustomString(format!(
-                "not a leaf at pos {}",
-                pos0
+                "not a leaf at pos {pos0}"
             )));
         }
 
         // check we actually have a hash in the MMR at this pos
         self.get_hash(pos0)?
-            .ok_or_else(|| MMRBackendErr::CustomString(format!("no element at pos {}", pos0)))?;
+            .ok_or_else(|| MMRBackendErr::CustomString(format!("no element at pos {pos0}")))?;
 
         let family_branch = family_branch(pos0, size);
 

--- a/src/chain/mmr/prune_list.rs
+++ b/src/chain/mmr/prune_list.rs
@@ -291,9 +291,7 @@ impl<'a> PruneList<'a> {
         let max = self.bitmap.maximum().unwrap_or(0) as u64;
         assert!(
             pos0 >= max,
-            "prune list append only - pos={} bitmap.maximum={}",
-            pos0,
-            max
+            "prune list append only - pos={pos0} bitmap.maximum={max}"
         );
 
         let (parent0, sibling0) = family(pos0);

--- a/src/global.rs
+++ b/src/global.rs
@@ -105,7 +105,7 @@ pub fn get_cached_genesis(chain_id: u8, chain_config: &ChainConfig) -> Arc<Block
 /// Retrieves the RandomX context for the given key
 pub fn get_randomx_ctx(key: &str) -> Arc<Context> {
     let nn: &str = &crate::settings::SETTINGS.node.network_name;
-    let key = format!("{}.{}.{}", RANDOMX_KEY_PREFIX, nn, key);
+    let key = format!("{RANDOMX_KEY_PREFIX}.{nn}.{key}");
     let key = Hash256::hash_from_slice(key, "purplecoinminer");
     let mut nnmux = (*RANDOMX_CTX_STORE).lock();
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -120,21 +120,45 @@ impl Application for GUI {
             .tab_bar_theme
             .unwrap_or_default();
 
-        Tabs::new(self.active_tab, Message::TabSelected)
-            .push(self.overview_tab.tab_label(), self.overview_tab.view())
-            .push(
-                self.send_and_receive_tab.tab_label(),
-                self.send_and_receive_tab.view(),
-            )
-            .push(self.trade_tab.tab_label(), self.trade_tab.view())
-            .push(self.settings_tab.tab_label(), self.settings_tab.view())
-            .tab_bar_style(theme)
-            .icon_font(ICON_FONT)
-            .tab_bar_position(match position {
-                TabBarPosition::Top => iced_aw::TabBarPosition::Top,
-                TabBarPosition::Bottom => iced_aw::TabBarPosition::Bottom,
-            })
-            .into()
+        let mut aaa = Tabs::new(self.active_tab, Message::TabSelected);
+        println!("1");
+        aaa = aaa.push(self.overview_tab.tab_label(), self.overview_tab.view());
+        println!("1");
+        aaa = aaa.push(
+            self.send_and_receive_tab.tab_label(),
+            self.send_and_receive_tab.view(),
+        );
+        println!("1");
+        aaa = aaa.push(self.trade_tab.tab_label(), self.trade_tab.view());
+        println!("1");
+        aaa = aaa.push(self.settings_tab.tab_label(), self.settings_tab.view());
+        println!("1");
+        aaa = aaa.tab_bar_style(theme);
+        println!("1");
+        aaa = aaa.icon_font(ICON_FONT);
+        println!("1");
+        aaa = aaa.tab_bar_position(match position {
+            TabBarPosition::Top => iced_aw::TabBarPosition::Top,
+            TabBarPosition::Bottom => iced_aw::TabBarPosition::Bottom,
+        });
+        println!("1");
+        aaa.into()
+
+        // Tabs::new(self.active_tab, Message::TabSelected)
+        //     .push(self.overview_tab.tab_label(), self.overview_tab.view())
+        //     .push(
+        //         self.send_and_receive_tab.tab_label(),
+        //         self.send_and_receive_tab.view(),
+        //     )
+        //     .push(self.trade_tab.tab_label(), self.trade_tab.view())
+        //     .push(self.settings_tab.tab_label(), self.settings_tab.view())
+        //     .tab_bar_style(theme)
+        //     .icon_font(ICON_FONT)
+        //     .tab_bar_position(match position {
+        //         TabBarPosition::Top => iced_aw::TabBarPosition::Top,
+        //         TabBarPosition::Bottom => iced_aw::TabBarPosition::Bottom,
+        //     })
+        //     .into()
     }
 
     fn subscription(&self) -> Subscription<Message> {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -120,45 +120,21 @@ impl Application for GUI {
             .tab_bar_theme
             .unwrap_or_default();
 
-        let mut aaa = Tabs::new(self.active_tab, Message::TabSelected);
-        println!("1");
-        aaa = aaa.push(self.overview_tab.tab_label(), self.overview_tab.view());
-        println!("1");
-        aaa = aaa.push(
-            self.send_and_receive_tab.tab_label(),
-            self.send_and_receive_tab.view(),
-        );
-        println!("1");
-        aaa = aaa.push(self.trade_tab.tab_label(), self.trade_tab.view());
-        println!("1");
-        aaa = aaa.push(self.settings_tab.tab_label(), self.settings_tab.view());
-        println!("1");
-        aaa = aaa.tab_bar_style(theme);
-        println!("1");
-        aaa = aaa.icon_font(ICON_FONT);
-        println!("1");
-        aaa = aaa.tab_bar_position(match position {
-            TabBarPosition::Top => iced_aw::TabBarPosition::Top,
-            TabBarPosition::Bottom => iced_aw::TabBarPosition::Bottom,
-        });
-        println!("1");
-        aaa.into()
-
-        // Tabs::new(self.active_tab, Message::TabSelected)
-        //     .push(self.overview_tab.tab_label(), self.overview_tab.view())
-        //     .push(
-        //         self.send_and_receive_tab.tab_label(),
-        //         self.send_and_receive_tab.view(),
-        //     )
-        //     .push(self.trade_tab.tab_label(), self.trade_tab.view())
-        //     .push(self.settings_tab.tab_label(), self.settings_tab.view())
-        //     .tab_bar_style(theme)
-        //     .icon_font(ICON_FONT)
-        //     .tab_bar_position(match position {
-        //         TabBarPosition::Top => iced_aw::TabBarPosition::Top,
-        //         TabBarPosition::Bottom => iced_aw::TabBarPosition::Bottom,
-        //     })
-        //     .into()
+        Tabs::new(self.active_tab, Message::TabSelected)
+            .push(self.overview_tab.tab_label(), self.overview_tab.view())
+            .push(
+                self.send_and_receive_tab.tab_label(),
+                self.send_and_receive_tab.view(),
+            )
+            .push(self.trade_tab.tab_label(), self.trade_tab.view())
+            .push(self.settings_tab.tab_label(), self.settings_tab.view())
+            .tab_bar_style(theme)
+            .icon_font(ICON_FONT)
+            .tab_bar_position(match position {
+                TabBarPosition::Top => iced_aw::TabBarPosition::Top,
+                TabBarPosition::Bottom => iced_aw::TabBarPosition::Bottom,
+            })
+            .into()
     }
 
     fn subscription(&self) -> Subscription<Message> {

--- a/src/gui/overview.rs
+++ b/src/gui/overview.rs
@@ -101,7 +101,7 @@ impl Tab for OverviewTab {
                                         .width(Length::FillPortion(1)),
                                 )
                                 .push(
-                                    Text::new(format!("{:.18}  XPU", available))
+                                    Text::new(format!("{available:.18}  XPU"))
                                         .size(16)
                                         .horizontal_alignment(Horizontal::Right)
                                         .width(Length::FillPortion(1)),
@@ -117,7 +117,7 @@ impl Tab for OverviewTab {
                                         .width(Length::FillPortion(1)),
                                 )
                                 .push(
-                                    Text::new(format!("{:.18}  XPU", pending))
+                                    Text::new(format!("{pending:.18}  XPU"))
                                         .size(16)
                                         .horizontal_alignment(Horizontal::Right)
                                         .width(Length::FillPortion(1)),
@@ -134,7 +134,7 @@ impl Tab for OverviewTab {
                                         .width(Length::FillPortion(1)),
                                 )
                                 .push(
-                                    Text::new(format!("{:.18}  XPU", total))
+                                    Text::new(format!("{total:.18}  XPU"))
                                         .size(16)
                                         .horizontal_alignment(Horizontal::Right)
                                         .width(Length::FillPortion(1)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,8 +335,7 @@ fn verify_addresses_checksum(addresses_path: &str, addresses_raw: &str) {
 
         if checksum != oracle_checksum {
             panic!(
-                "Addresses file checksum verification failed! Got: {}, Expected: {}",
-                checksum, oracle_checksum
+                "Addresses file checksum verification failed! Got: {checksum}, Expected: {oracle_checksum}"
             );
         }
     }

--- a/src/miner/mod.rs
+++ b/src/miner/mod.rs
@@ -340,7 +340,7 @@ impl Miner {
                 Err(TryRecvError::Empty) => {}
 
                 Err(err) => {
-                    panic!("An error occured: {:?}", err);
+                    panic!("An error occured: {err:?}");
                 }
             }
         }

--- a/src/primitives/block.rs
+++ b/src/primitives/block.rs
@@ -745,7 +745,7 @@ impl BlockHeader {
             "testnet" => ADDRESSES_RAW_TESTNET,
 
             other => {
-                panic!("Invalid network: {}", other)
+                panic!("Invalid network: {other}")
             }
         };
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -72,36 +72,36 @@ impl Settings {
             for (k2, v) in inner {
                 match v {
                     DynamicConfVal::String(v) => {
-                        s = s.set_default(format!("{}.{}", k1, k2), v.as_str())?;
+                        s = s.set_default(format!("{k1}.{k2}"), v.as_str())?;
                     }
 
                     DynamicConfVal::Bool(v) => {
-                        s = s.set_default(format!("{}.{}", k1, k2), v.to_string())?;
+                        s = s.set_default(format!("{k1}.{k2}"), v.to_string())?;
                     }
 
                     DynamicConfVal::U16(v) => {
-                        s = s.set_default(format!("{}.{}", k1, k2), v.to_string())?;
+                        s = s.set_default(format!("{k1}.{k2}"), v.to_string())?;
                     }
 
                     DynamicConfVal::Sequence(v) => {
-                        s = s.set_default(format!("{}.{}", k1, k2), v.clone())?;
+                        s = s.set_default(format!("{k1}.{k2}"), v.clone())?;
                     }
 
                     DynamicConfVal::Option(v) => {
                         if let Some(v) = v {
-                            s = s.set_default(format!("{}.{}", k1, k2), v.as_str())?;
+                            s = s.set_default(format!("{k1}.{k2}"), v.as_str())?;
                         }
                     }
 
                     DynamicConfVal::OptionSequence(v) => {
                         if let Some(v) = v {
-                            s = s.set_default(format!("{}.{}", k1, k2), v.clone())?;
+                            s = s.set_default(format!("{k1}.{k2}"), v.clone())?;
                         }
                     }
 
                     DynamicConfVal::OptionSequenceByte(v) => {
                         if let Some(v) = v {
-                            s = s.set_default(format!("{}.{}", k1, k2), v.clone())?;
+                            s = s.set_default(format!("{k1}.{k2}"), v.clone())?;
                         }
                     }
                 }

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -154,6 +154,52 @@ impl VmTerm {
         Some(())
     }
 
+    pub fn sub_one(&mut self) -> Option<()> {
+        match self {
+            Self::Unsigned8(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Unsigned16(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Unsigned32(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Unsigned64(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Unsigned128(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::UnsignedBig(ref mut val) => {
+                *val -= 1;
+            }
+            Self::Signed8(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Signed16(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Signed32(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Signed64(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::Signed128(ref mut val) => {
+                *val = val.checked_sub(1)?;
+            }
+            Self::SignedBig(ref mut val) => {
+                *val -= 1;
+            }
+            _ => {
+                return None;
+            }
+        }
+
+        Some(())
+    }
+
     /// Returns the virtual heap size of the term in bytes
     pub fn size(&self) -> usize {
         match self {
@@ -206,7 +252,6 @@ impl VmTerm {
         }
     }
 
-    // TODO HANDLE ARRAYS
     pub fn equals_1(self) -> bool {
         match self {
             Self::Unsigned8(val) => val == 1_u8,

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -6,7 +6,7 @@
 
 use bincode::{Decode, Encode};
 use ibig::ops::Abs;
-use ibig::{ibig, IBig, UBig};
+use ibig::{ibig, ubig, IBig, UBig};
 use num_traits::identities::Zero;
 use std::fmt;
 
@@ -203,6 +203,25 @@ impl VmTerm {
                 }
                 size
             }
+        }
+    }
+
+    // TODO HANDLE ARRAYS
+    pub fn equals_1(self) -> bool {
+        match self {
+            Self::Unsigned8(val) => val == 1_u8,
+            Self::Unsigned16(val) => val == 1_u16,
+            Self::Unsigned32(val) => val == 1_u32,
+            Self::Unsigned64(val) => val == 1_u64,
+            Self::Unsigned128(val) => val == 1_u128,
+            Self::UnsignedBig(val) => val == ubig!(1),
+            Self::Signed8(val) => val == 1_i8,
+            Self::Signed16(val) => val == 1_i16,
+            Self::Signed32(val) => val == 1_i32,
+            Self::Signed64(val) => val == 1_i64,
+            Self::Signed128(val) => val == 1_i128,
+            Self::SignedBig(val) => val == ibig!(1),
+            _ => false
         }
     }
 }
@@ -578,7 +597,7 @@ impl Decode for VmTerm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ibig::ubig;
+    use ibig::{ubig, ibig};
 
     #[test]
     fn test_hash160_encode_decode() {
@@ -761,5 +780,34 @@ mod tests {
         let encoded = crate::codec::encode_to_vec(&t).unwrap();
         assert_eq!(&encoded, &[0x10]);
         assert_eq!(crate::codec::decode::<VmTerm>(&encoded).unwrap(), t);
+    }
+
+    #[test]
+    fn test_equals_1() {
+        assert_eq!(VmTerm::Unsigned8(1).equals_1(), true);
+        assert_eq!(VmTerm::Unsigned16(1).equals_1(), true);
+        assert_eq!(VmTerm::Unsigned32(1).equals_1(), true);
+        assert_eq!(VmTerm::Unsigned64(1).equals_1(), true);
+        assert_eq!(VmTerm::Unsigned128(1).equals_1(), true);
+        assert_eq!(VmTerm::UnsignedBig(ubig!(1)).equals_1(), true);
+        assert_eq!(VmTerm::Signed8(1).equals_1(), true);
+        assert_eq!(VmTerm::Signed16(1).equals_1(), true);
+        assert_eq!(VmTerm::Signed32(1).equals_1(), true);
+        assert_eq!(VmTerm::Signed64(1).equals_1(), true);
+        assert_eq!(VmTerm::Signed128(1).equals_1(), true);
+        assert_eq!(VmTerm::SignedBig(ibig!(1)).equals_1(), true);
+
+        assert_eq!(VmTerm::Unsigned8(10).equals_1(), false);
+        assert_eq!(VmTerm::Unsigned16(10).equals_1(), false);
+        assert_eq!(VmTerm::Unsigned32(10).equals_1(), false);
+        assert_eq!(VmTerm::Unsigned64(10).equals_1(), false);
+        assert_eq!(VmTerm::Unsigned128(10).equals_1(), false);
+        assert_eq!(VmTerm::UnsignedBig(ubig!(10)).equals_1(), false);
+        assert_eq!(VmTerm::Signed8(10).equals_1(), false);
+        assert_eq!(VmTerm::Signed16(10).equals_1(), false);
+        assert_eq!(VmTerm::Signed32(10).equals_1(), false);
+        assert_eq!(VmTerm::Signed64(10).equals_1(), false);
+        assert_eq!(VmTerm::Signed128(10).equals_1(), false);
+        assert_eq!(VmTerm::SignedBig(ibig!(10)).equals_1(), false);
     }
 }

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -266,7 +266,7 @@ impl VmTerm {
             Self::Signed64(val) => val == 1_i64,
             Self::Signed128(val) => val == 1_i128,
             Self::SignedBig(val) => val == ibig!(1),
-            _ => false
+            _ => false,
         }
     }
 }
@@ -642,7 +642,7 @@ impl Decode for VmTerm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ibig::{ubig, ibig};
+    use ibig::{ibig, ubig};
 
     #[test]
     fn test_hash160_encode_decode() {

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -174,6 +174,7 @@ pub enum OP {
     HasOutput = 0xde,
     HasColouredInput = 0xdf,
     HasColouredOutput = 0xe0,
+    Trap = 0xe1,
     Sha256 = 0xee,
     Sha512 = 0xef,
     Keccak256 = 0xf0,

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -173,6 +173,8 @@ impl Script {
         let mut exec_count = 0;
         let mut frame_stack: Vec<Frame> = Vec::with_capacity(MAX_FRAMES);
         let mut frame = Frame::new(0);
+        let mut script_outputs = vec![];
+
         for a in args.iter().rev().cloned() {
             memory_size += a.size();
             frame.stack.push(a);
@@ -212,6 +214,7 @@ impl Script {
                         input_stack,
                         output_stack,
                         output_stack_idx_map,
+                        &mut script_outputs,
                         key,
                     );
                     exec_count += 1;
@@ -282,6 +285,7 @@ impl Script {
                                     frame.stack.push(VmTerm::Unsigned8(*byte));
                                     frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                     frame.i_ptr += 1;
+                                    memory_size += 1;
                                 }
 
                                 ScriptEntry::Opcode(op) => {
@@ -524,6 +528,7 @@ impl<'a> ScriptExecutor<'a> {
         input_stack: &[Input],
         output_stack: &mut Vec<Output>,
         output_stack_idx_map: &mut HashMap<(Address, Hash160), u16>,
+        script_outputs: &mut Vec<VmTerm>,
         key: &str,
     ) {
         match self.state {
@@ -575,8 +580,23 @@ impl<'a> ScriptExecutor<'a> {
                         return;
                     }
 
-                    let rolled = exec_stack.remove(*idx as usize);
+                    let rolled = exec_stack.remove(exec_stack.len() - 1 - *idx as usize);
                     exec_stack.push(rolled);
+
+                    self.state = ScriptExecutorState::ExpectingInitialOP;
+                }
+
+                (OP::PickToScriptOuts, ScriptEntry::Byte(idx)) => {
+                    if *idx as usize >= exec_stack.len() {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::IndexOutOfBounds,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let cloned = exec_stack[exec_stack.len() - 1 - *idx as usize].clone();
+                    script_outputs.push(cloned);
 
                     self.state = ScriptExecutorState::ExpectingInitialOP;
                 }
@@ -607,8 +627,11 @@ impl<'a> ScriptExecutor<'a> {
                     }
 
                     let amount = exec_stack.pop().unwrap();
+                    *memory_size -= amount.size();
                     let address = exec_stack.pop().unwrap();
+                    *memory_size -= address.size();
                     let script_hash = exec_stack.pop().unwrap();
+                    *memory_size -= script_hash.size();
 
                     match (amount, address, script_hash) {
                         (
@@ -638,6 +661,9 @@ impl<'a> ScriptExecutor<'a> {
                                 output_stack[*idx as usize].amount += amount;
                                 output_stack[*idx as usize].inputs_hash = inputs_hash;
                                 output_stack[*idx as usize].compute_hash(key);
+                                output_stack[*idx as usize].script_outs = script_outputs.clone();
+
+                                *script_outputs = vec![];
                             } else {
                                 let mut output = Output {
                                     amount,
@@ -647,7 +673,7 @@ impl<'a> ScriptExecutor<'a> {
                                     coloured_address: None,
                                     inputs_hash: inputs_hash.clone(),
                                     idx: output_stack.len() as u16,
-                                    script_outs: vec![],
+                                    script_outs: script_outputs.clone(),
                                     hash: None,
                                 };
 
@@ -655,6 +681,7 @@ impl<'a> ScriptExecutor<'a> {
                                 output_stack_idx_map
                                     .insert((address, script_hash), output_stack.len() as u16);
                                 output_stack.push(output);
+                                *script_outputs = vec![];
                             }
 
                             if output_stack.len() > MAX_OUT_STACK {
@@ -718,6 +745,9 @@ impl<'a> ScriptExecutor<'a> {
                                 output_stack[*idx as usize].amount += amount;
                                 output_stack[*idx as usize].inputs_hash = inputs_hash;
                                 output_stack[*idx as usize].compute_hash(key);
+                                output_stack[*idx as usize].script_outs = script_outputs.clone();
+
+                                *script_outputs = vec![];
                             } else {
                                 let mut output = Output {
                                     amount,
@@ -727,7 +757,7 @@ impl<'a> ScriptExecutor<'a> {
                                     coloured_address: None,
                                     inputs_hash: inputs_hash.clone(),
                                     idx: output_stack.len() as u16,
-                                    script_outs: vec![],
+                                    script_outs: script_outputs.clone(),
                                     hash: None,
                                 };
 
@@ -735,6 +765,7 @@ impl<'a> ScriptExecutor<'a> {
                                 output_stack_idx_map
                                     .insert((address, script_hash), output_stack.len() as u16);
                                 output_stack.push(output);
+                                *script_outputs = vec![];
 
                                 if output_stack.len() > MAX_OUT_STACK {
                                     self.state = ScriptExecutorState::Error(
@@ -767,9 +798,13 @@ impl<'a> ScriptExecutor<'a> {
                     }
 
                     let amount = exec_stack.pop().unwrap();
+                    *memory_size -= amount.size();
                     let address = exec_stack.pop().unwrap();
+                    *memory_size -= address.size();
                     let script_hash = exec_stack.pop().unwrap();
+                    *memory_size -= script_hash.size();
                     let coinbase_height = exec_stack.pop().unwrap();
+                    *memory_size -= coinbase_height.size();
 
                     match (amount, address, script_hash, coinbase_height) {
                         (
@@ -786,12 +821,13 @@ impl<'a> ScriptExecutor<'a> {
                                 coloured_address: None,
                                 inputs_hash: inputs_hash.clone(),
                                 idx: output_stack.len() as u16,
-                                script_outs: vec![],
+                                script_outs: script_outputs.clone(),
                                 hash: None,
                             };
 
                             output.compute_hash(key);
                             output_stack.push(output);
+                            *script_outputs = vec![];
 
                             self.state = ScriptExecutorState::ExpectingInitialOP;
                         }
@@ -818,7 +854,7 @@ impl<'a> ScriptExecutor<'a> {
                 }
 
                 ScriptEntry::Opcode(OP::BreakIf) => {
-                    if exec_stack.len() < 1 {
+                    if exec_stack.is_empty() {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -827,14 +863,15 @@ impl<'a> ScriptExecutor<'a> {
                     }
 
                     let top = exec_stack.pop().unwrap();
-                    // TODO substract mem size?
+                    *memory_size -= top.size();
+
                     if top.equals_1() {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
                 }
 
                 ScriptEntry::Opcode(OP::BreakIfn) => {
-                    if exec_stack.len() < 1 {
+                    if exec_stack.is_empty() {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -843,7 +880,8 @@ impl<'a> ScriptExecutor<'a> {
                     }
 
                     let top = exec_stack.pop().unwrap();
-                    // TODO substract mem size?
+                    *memory_size -= top.size();
+
                     if !top.equals_1() {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
@@ -859,8 +897,10 @@ impl<'a> ScriptExecutor<'a> {
                     }
 
                     let e1 = exec_stack.pop().unwrap();
+                    *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
-                    // TODO substract mem size?
+                    *memory_size -= e2.size();
+
                     if e1 == e2 {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
@@ -876,8 +916,10 @@ impl<'a> ScriptExecutor<'a> {
                     }
 
                     let e1 = exec_stack.pop().unwrap();
+                    *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
-                    // TODO substract mem size?
+                    *memory_size -= e2.size();
+
                     if e1 != e2 {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
@@ -899,9 +941,55 @@ impl<'a> ScriptExecutor<'a> {
                         );
                         return;
                     }
-
                     let e = exec_stack.pop().unwrap();
                     *memory_size -= e.size();
+
+                    self.state = ScriptExecutorState::ExpectingInitialOP;
+                }
+
+                ScriptEntry::Opcode(OP::Dup) => {
+                    if exec_stack.is_empty() {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let c = exec_stack[exec_stack.len() - 1].clone();
+                    *memory_size += c.size();
+                    exec_stack.push(c);
+
+                    self.state = ScriptExecutorState::ExpectingInitialOP;
+                }
+                
+                ScriptEntry::Opcode(OP::Nip) => {
+                    if exec_stack.len() < 2 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let r = exec_stack.remove(exec_stack.len() - 2);
+                    *memory_size -= r.size();
+
+                    self.state = ScriptExecutorState::ExpectingInitialOP;
+                }
+
+                ScriptEntry::Opcode(OP::Over) => {
+                    if exec_stack.len() < 2 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let c = exec_stack[exec_stack.len() - 2].clone();
+                    *memory_size += c.size();
+                    exec_stack.push(c);
 
                     self.state = ScriptExecutorState::ExpectingInitialOP;
                 }
@@ -953,11 +1041,9 @@ impl<'a> ScriptExecutor<'a> {
                         );
                         return;
                     }
-
                     let e1 = exec_stack.pop().unwrap();
-                    let e2 = exec_stack.pop().unwrap();
-
                     *memory_size -= e1.size();
+                    let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
                     self.state = ScriptExecutorState::ExpectingInitialOP;
@@ -1009,6 +1095,27 @@ impl<'a> ScriptExecutor<'a> {
                 }
 
                 ScriptEntry::Opcode(OP::Over2) => {
+                    if exec_stack.len() < 4 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let c1 = exec_stack[exec_stack.len() - 3].clone();
+                    let c2 = exec_stack[exec_stack.len() - 4].clone();
+
+                    *memory_size += c1.size();
+                    *memory_size += c2.size();
+
+                    exec_stack.push(c2);
+                    exec_stack.push(c1);
+
+                    self.state = ScriptExecutorState::ExpectingInitialOP;
+                }
+
+                ScriptEntry::Opcode(OP::Rot2) => {
                     if exec_stack.len() < 3 {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
@@ -1039,6 +1146,7 @@ impl<'a> ScriptExecutor<'a> {
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
                         );
+                        return;
                     }
 
                     let mut last = exec_stack.last_mut().unwrap();
@@ -1050,6 +1158,46 @@ impl<'a> ScriptExecutor<'a> {
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
                         );
                     }
+                }
+
+                ScriptEntry::Opcode(OP::Sub1) => {
+                    if exec_stack.is_empty() {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let mut last = exec_stack.last_mut().unwrap();
+                    if last.sub_one().is_some() {
+                        self.state = ScriptExecutorState::ExpectingInitialOP;
+                    } else {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                    }
+                }
+
+                ScriptEntry::Opcode(OP::PopToScriptOuts) => {
+                    if exec_stack.is_empty() {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let e = exec_stack.pop().unwrap();
+                    *memory_size -= e.size();
+                    script_outputs.push(e);
+
+                    self.state = ScriptExecutorState::ExpectingInitialOP;
+                }
+
+                ScriptEntry::Opcode(OP::PickToScriptOuts) => {
+                    self.state = ScriptExecutorState::ExpectingIndexU8(OP::PickToScriptOuts);
                 }
 
                 ScriptEntry::Opcode(OP::ClearStack) => {
@@ -1581,8 +1729,85 @@ pub enum ExecutionResult {
 
 #[cfg(test)]
 mod tests {
+    use std::string;
+
     use super::*;
     use rayon::prelude::*;
+    use crate::consensus::Money;
+
+    pub struct TestBaseArgs {
+        args: Vec<VmTerm>,
+        ins: Vec<Input>,
+        out: Vec<Output>
+    }
+
+    fn get_test_base_args(ss: &Script, out_amount: Money, out_script: Vec<VmTerm>, push_out_cycles: usize, key: &str) -> TestBaseArgs {
+        let sh = ss.to_script_hash(key);
+        let args = vec![
+            VmTerm::Signed128(30),
+            VmTerm::Hash160([0; 20]),
+            VmTerm::Hash160(sh.0),
+        ];
+        let mut ins = vec![Input {
+            out: None,
+            nsequence: 0xffffffff,
+            colour_script_args: None,
+            spending_pkey: None,
+            spend_proof: None,
+            witness: None,
+            script: ss.clone(),
+            script_args: args.clone(),
+            colour_proof: None,
+            colour_proof_without_address: None,
+            colour_script: None,
+            hash: None,
+        }]
+        .iter()
+        .cloned()
+        .map(|mut i| {
+            i.compute_hash(key);
+            i
+        })
+        .collect::<Vec<_>>();
+        
+        // Prepare output
+        let ins_hashes: Vec<u8> = ins.iter_mut().fold(vec![], |mut acc, v: &mut Input| {
+            v.compute_hash(key);
+            acc.extend(v.hash().unwrap().0);
+            acc
+        });
+        let inputs_hash = Hash160::hash_from_slice(ins_hashes.as_slice(), key);
+        let inputs_hash: Hash160 = ins.iter().cloned().cycle().take(push_out_cycles).fold(
+            inputs_hash.clone(),
+            |mut acc: Hash160, v: Input| {
+                let inputs_hashes = vec![acc.0, inputs_hash.0]
+                    .iter()
+                    .flatten()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                acc = Hash160::hash_from_slice(inputs_hashes.as_slice(), key);
+                acc
+            },
+        );
+        let mut oracle_out = Output {
+            address: Some(Hash160::zero().to_address()),
+            amount: out_amount,
+            script_hash: sh,
+            inputs_hash,
+            coloured_address: None,
+            coinbase_height: None,
+            hash: None,
+            script_outs: out_script,
+            idx: 0,
+        };
+        oracle_out.compute_hash(key);
+
+        TestBaseArgs {
+            args: args,
+            ins: ins,
+            out: vec![oracle_out]
+        }
+    }
 
     #[test]
     fn it_simple_spends() {
@@ -1665,74 +1890,15 @@ mod tests {
                 ScriptEntry::Opcode(OP::Verify),
             ],
         };
-        let sh = ss.to_script_hash(key);
+        let base: TestBaseArgs = get_test_base_args(&ss, 90, vec![], 2, &key);
         let mut idx_map = HashMap::new();
-        let args = vec![
-            VmTerm::Signed128(30),
-            VmTerm::Hash160([0; 20]),
-            VmTerm::Hash160(sh.0),
-        ];
-        let mut ins = vec![Input {
-            out: None,
-            nsequence: 0xffffffff,
-            colour_script_args: None,
-            spending_pkey: None,
-            spend_proof: None,
-            witness: None,
-            script: ss.clone(),
-            script_args: args.clone(),
-            colour_proof: None,
-            colour_proof_without_address: None,
-            colour_script: None,
-            hash: None,
-        }]
-        .iter()
-        .cloned()
-        .map(|mut i| {
-            i.compute_hash(key);
-            i
-        })
-        .collect::<Vec<_>>();
         let mut outs = vec![];
 
-        let ins_hashes: Vec<u8> = ins.iter_mut().fold(vec![], |mut acc, v: &mut Input| {
-            v.compute_hash(key);
-            acc.extend(v.hash().unwrap().0);
-            acc
-        });
-
-        let inputs_hash = Hash160::hash_from_slice(ins_hashes.as_slice(), key);
-
-        let inputs_hash: Hash160 = ins.iter().cloned().cycle().take(2).fold(
-            inputs_hash.clone(),
-            |mut acc: Hash160, v: Input| {
-                let inputs_hashes = vec![acc.0, inputs_hash.0]
-                    .iter()
-                    .flatten()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                acc = Hash160::hash_from_slice(inputs_hashes.as_slice(), key);
-                acc
-            },
-        );
-        let mut oracle_out = Output {
-            address: Some(Hash160::zero().to_address()),
-            amount: 90,
-            script_hash: sh,
-            inputs_hash,
-            coloured_address: None,
-            coinbase_height: None,
-            hash: None,
-            script_outs: vec![],
-            idx: 0,
-        };
-        oracle_out.compute_hash(key);
-
         assert_eq!(
-            ss.execute(&args, &ins, &mut outs, &mut idx_map, [0; 32], key),
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
             Ok(ExecutionResult::OkVerify).into()
         );
-        assert_eq!(outs, vec![oracle_out]);
+        assert_eq!(outs, base.out);
     }
 
     #[test]
@@ -1762,74 +1928,16 @@ mod tests {
                 ScriptEntry::Opcode(OP::Verify),
             ],
         };
-        let sh = ss.to_script_hash(key);
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 60, vec![], 1, &key);
         let mut idx_map = HashMap::new();
-        let args = vec![
-            VmTerm::Signed128(30),
-            VmTerm::Hash160([0; 20]),
-            VmTerm::Hash160(sh.0),
-        ];
-        let mut ins = vec![Input {
-            out: None,
-            nsequence: 0xffffffff,
-            colour_script_args: None,
-            spending_pkey: None,
-            spend_proof: None,
-            witness: None,
-            script: ss.clone(),
-            script_args: args.clone(),
-            colour_proof: None,
-            colour_proof_without_address: None,
-            colour_script: None,
-            hash: None,
-        }]
-        .iter()
-        .cloned()
-        .map(|mut i| {
-            i.compute_hash(key);
-            i
-        })
-        .collect::<Vec<_>>();
         let mut outs = vec![];
 
-        let ins_hashes: Vec<u8> = ins.iter_mut().fold(vec![], |mut acc, v: &mut Input| {
-            v.compute_hash(key);
-            acc.extend(v.hash().unwrap().0);
-            acc
-        });
-
-        let inputs_hash = Hash160::hash_from_slice(ins_hashes.as_slice(), key);
-
-        let inputs_hash: Hash160 = ins.iter().cloned().cycle().take(1).fold(
-            inputs_hash.clone(),
-            |mut acc: Hash160, v: Input| {
-                let inputs_hashes = vec![acc.0, inputs_hash.0]
-                    .iter()
-                    .flatten()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                acc = Hash160::hash_from_slice(inputs_hashes.as_slice(), key);
-                acc
-            },
-        );
-        let mut oracle_out = Output {
-            address: Some(Hash160::zero().to_address()),
-            amount: 60,
-            script_hash: sh,
-            inputs_hash,
-            coloured_address: None,
-            coinbase_height: None,
-            hash: None,
-            script_outs: vec![],
-            idx: 0,
-        };
-        oracle_out.compute_hash(key);
-
         assert_eq!(
-            ss.execute(&args, &ins, &mut outs, &mut idx_map, [0; 32], key),
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
             Ok(ExecutionResult::OkVerify).into()
         );
-        assert_eq!(outs, vec![oracle_out]);
+        assert_eq!(outs, base.out);
     }
 
     #[test]
@@ -1857,74 +1965,16 @@ mod tests {
                 ScriptEntry::Opcode(OP::Verify),
             ],
         };
-        let sh = ss.to_script_hash(key);
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
         let mut idx_map = HashMap::new();
-        let args = vec![
-            VmTerm::Signed128(30),
-            VmTerm::Hash160([0; 20]),
-            VmTerm::Hash160(sh.0),
-        ];
-        let mut ins = vec![Input {
-            out: None,
-            nsequence: 0xffffffff,
-            colour_script_args: None,
-            spending_pkey: None,
-            spend_proof: None,
-            witness: None,
-            script: ss.clone(),
-            script_args: args.clone(),
-            colour_proof: None,
-            colour_proof_without_address: None,
-            colour_script: None,
-            hash: None,
-        }]
-        .iter()
-        .cloned()
-        .map(|mut i| {
-            i.compute_hash(key);
-            i
-        })
-        .collect::<Vec<_>>();
         let mut outs = vec![];
-
-        let ins_hashes: Vec<u8> = ins.iter_mut().fold(vec![], |mut acc, v: &mut Input| {
-            v.compute_hash(key);
-            acc.extend(v.hash().unwrap().0);
-            acc
-        });
-
-        let inputs_hash = Hash160::hash_from_slice(ins_hashes.as_slice(), key);
-
-        let inputs_hash: Hash160 = ins.iter().cloned().cycle().take(0).fold(
-            inputs_hash.clone(),
-            |mut acc: Hash160, v: Input| {
-                let inputs_hashes = vec![acc.0, inputs_hash.0]
-                    .iter()
-                    .flatten()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                acc = Hash160::hash_from_slice(inputs_hashes.as_slice(), key);
-                acc
-            },
-        );
-        let mut oracle_out = Output {
-            address: Some(Hash160::zero().to_address()),
-            amount: 30,
-            script_hash: sh,
-            inputs_hash,
-            coloured_address: None,
-            coinbase_height: None,
-            hash: None,
-            script_outs: vec![],
-            idx: 0,
-        };
-        oracle_out.compute_hash(key);
-
+        
         assert_eq!(
-            ss.execute(&args, &ins, &mut outs, &mut idx_map, [0; 32], key),
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
             Ok(ExecutionResult::OkVerify).into()
         );
-        assert_eq!(outs, vec![oracle_out]);
+        assert_eq!(outs, base.out);
     }
 
     #[test]
@@ -1952,74 +2002,55 @@ mod tests {
                 ScriptEntry::Opcode(OP::Verify),
             ],
         };
-        let sh = ss.to_script_hash(key);
+        
+        let base: TestBaseArgs = get_test_base_args(&ss, 60, vec![], 1, &key);
         let mut idx_map = HashMap::new();
-        let args = vec![
-            VmTerm::Signed128(30),
-            VmTerm::Hash160([0; 20]),
-            VmTerm::Hash160(sh.0),
-        ];
-        let mut ins = vec![Input {
-            out: None,
-            nsequence: 0xffffffff,
-            colour_script_args: None,
-            spending_pkey: None,
-            spend_proof: None,
-            witness: None,
-            script: ss.clone(),
-            script_args: args.clone(),
-            colour_proof: None,
-            colour_proof_without_address: None,
-            colour_script: None,
-            hash: None,
-        }]
-        .iter()
-        .cloned()
-        .map(|mut i| {
-            i.compute_hash(key);
-            i
-        })
-        .collect::<Vec<_>>();
         let mut outs = vec![];
 
-        let ins_hashes: Vec<u8> = ins.iter_mut().fold(vec![], |mut acc, v: &mut Input| {
-            v.compute_hash(key);
-            acc.extend(v.hash().unwrap().0);
-            acc
-        });
-
-        let inputs_hash = Hash160::hash_from_slice(ins_hashes.as_slice(), key);
-
-        let inputs_hash: Hash160 = ins.iter().cloned().cycle().take(1).fold(
-            inputs_hash.clone(),
-            |mut acc: Hash160, v: Input| {
-                let inputs_hashes = vec![acc.0, inputs_hash.0]
-                    .iter()
-                    .flatten()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                acc = Hash160::hash_from_slice(inputs_hashes.as_slice(), key);
-                acc
-            },
-        );
-        let mut oracle_out = Output {
-            address: Some(Hash160::zero().to_address()),
-            amount: 60,
-            script_hash: sh,
-            inputs_hash,
-            coloured_address: None,
-            coinbase_height: None,
-            hash: None,
-            script_outs: vec![],
-            idx: 0,
-        };
-        oracle_out.compute_hash(key);
-
         assert_eq!(
-            ss.execute(&args, &ins, &mut outs, &mut idx_map, [0; 32], key),
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
             Ok(ExecutionResult::OkVerify).into()
         );
-        assert_eq!(outs, vec![oracle_out]);
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_breaks_loop_if_values_equal_test_2() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x06),
+                ScriptEntry::Opcode(OP::Loop),
+                ScriptEntry::Opcode(OP::Pick),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Pick),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Pick),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Sub1),
+                ScriptEntry::Opcode(OP::Pick),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::BreakIfEq),
+                ScriptEntry::Opcode(OP::End),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+        
+        let base: TestBaseArgs = get_test_base_args(&ss, 90, vec![], 2, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
     }
 
     #[test]
@@ -2278,5 +2309,658 @@ mod tests {
         let encoded = crate::codec::encode_to_vec(&script).unwrap();
         let decoded: Script = crate::codec::decode(&encoded).unwrap();
         assert_eq!(decoded, script);
+    }
+
+    #[test]
+    fn it_rolls_on_stack_outputs_with_pop() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Roll),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Roll),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(0), VmTerm::Unsigned8(1), VmTerm::Unsigned8(2)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_rolls_on_stack_outputs_with_pick() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Roll),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Roll),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::PickToScriptOuts),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::PickToScriptOuts),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::PickToScriptOuts),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Drop),
+                ScriptEntry::Opcode(OP::Drop2),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(2), VmTerm::Unsigned8(1), VmTerm::Unsigned8(0)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_dups_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x1),
+                ScriptEntry::Opcode(OP::Dup),
+                ScriptEntry::Opcode(OP::Dup),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(1), VmTerm::Unsigned8(1), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_nips_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x04),
+                ScriptEntry::Opcode(OP::Nip),
+                ScriptEntry::Opcode(OP::Nip),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(4), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_overs_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Over),
+                ScriptEntry::Opcode(OP::Over2),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(2), VmTerm::Unsigned8(1), VmTerm::Unsigned8(2), VmTerm::Unsigned8(3), VmTerm::Unsigned8(2), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_swaps_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Swap),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(2), VmTerm::Unsigned8(3), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_tucks_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Tuck),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(3), VmTerm::Unsigned8(2), VmTerm::Unsigned8(3), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_drops_2_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x05),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x04),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Drop2),
+                ScriptEntry::Opcode(OP::Drop2),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(5)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_dups_2_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Dup2),
+                ScriptEntry::Opcode(OP::Dup2),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(2), VmTerm::Unsigned8(1), VmTerm::Unsigned8(2), VmTerm::Unsigned8(1),VmTerm::Unsigned8(2), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_dups_3_on_stack() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Dup3),
+                ScriptEntry::Opcode(OP::Dup3),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let script_output: Vec<VmTerm> = vec![VmTerm::Unsigned8(3), VmTerm::Unsigned8(2), VmTerm::Unsigned8(1), VmTerm::Unsigned8(3), VmTerm::Unsigned8(2), VmTerm::Unsigned8(1), VmTerm::Unsigned8(3), VmTerm::Unsigned8(2), VmTerm::Unsigned8(1)];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_fails_drop_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Drop),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_dup_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Dup),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_nip_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Nip),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_over_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Over),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_roll_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x03),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x04),
+                ScriptEntry::Opcode(OP::Roll),
+                ScriptEntry::Byte(0x05),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::IndexOutOfBounds, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_swap_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Swap),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_tuck_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Tuck),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_drop_2_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Drop2),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_dup_2_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Dup2),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_dup_3_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Dup3),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
+    }
+
+    #[test]
+    fn it_fails_over_2_when_stack_length_is_lower() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x1),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x2),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x3),
+                ScriptEntry::Opcode(OP::Over2),
+                ScriptEntry::Opcode(OP::Verify),
+            ]
+        };
+
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, vec![], 0, &key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+        
+        assert_eq!(
+            ss.execute(&base.args, &base.ins, &mut outs, &mut idx_map, [0; 32], key),
+            Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
+        );
     }
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -142,7 +142,7 @@ impl XPub {
             depth: 0x01,
             pub_key: PublicKey(
                 extended_key
-                    .derived_key_simple(format!("{}", child_number))
+                    .derived_key_simple(format!("{child_number}"))
                     .key,
             ),
         }
@@ -187,7 +187,7 @@ impl XPriv {
             child_number,
             depth: 0x01,
             secret_key: extended_key
-                .derived_key_simple(format!("{}", child_number))
+                .derived_key_simple(format!("{child_number}"))
                 .key
                 .to_bytes(),
         }
@@ -408,7 +408,7 @@ impl HDWallet {
         }
 
         let mut meta: HashMap<String, String> = HashMap::with_capacity(1);
-        meta.insert("c".to_owned(), format!("{}", tx_time));
+        meta.insert("c".to_owned(), format!("{tx_time}"));
 
         self.txs_meta.insert(*tx_hash, meta);
         self.txs.push(tx);
@@ -433,10 +433,10 @@ impl HDWallet {
         let now = Utc::now().timestamp();
 
         // Created at
-        meta.insert("c".to_owned(), format!("{}", now));
+        meta.insert("c".to_owned(), format!("{now}"));
 
         // Updated at
-        meta.insert("u".to_owned(), format!("{}", now));
+        meta.insert("u".to_owned(), format!("{now}"));
 
         self.txs_meta.insert(zero, meta);
     }
@@ -459,7 +459,7 @@ pub fn dump_hdwallet(wallet: &HDWallet, wallet_name: &str) -> Result<(), &'stati
     wallets_path.push("wallets");
 
     let mut wallet_path = wallets_path.clone();
-    wallet_path.push(format!("{}.dat", wallet_name));
+    wallet_path.push(format!("{wallet_name}.dat"));
 
     wallet.dump(wallet_path)
 }
@@ -475,7 +475,7 @@ pub fn load_hdwallet(wallet_name: &str) -> Result<HDWallet, &'static str> {
     wallets_path.push("wallets");
 
     let mut wallet_path = wallets_path.clone();
-    wallet_path.push(format!("{}.dat", wallet_name));
+    wallet_path.push(format!("{wallet_name}.dat"));
 
     HDWallet::load(wallet_path)
 }
@@ -491,7 +491,7 @@ pub fn generate_hdwallet(wallet_name: &str, passphrase: &str) -> Result<HDWallet
     wallets_path.push("wallets");
 
     let mut wallet_path = wallets_path.clone();
-    wallet_path.push(format!("{}.dat", wallet_name));
+    wallet_path.push(format!("{wallet_name}.dat"));
 
     if wallet_path.exists() {
         return Err("wallet already exists");


### PR DESCRIPTION
Finished OpCodes + tests (unmarked misses the tests):

- [x] BreakIf
- [x] BreakIfn
- [x] BreakIfNeq
- [x] Drop
- [x] Dup
- [x] Nip
- [x] Over
- [x] Roll 
- [x] PickToScriptOuts
- [x] PopToScriptOuts
- [x] Swap
- [x] Tuck
- [x] Drop2
- [x] Dup2
- [x] Dup3
- [x] Over2
- [x] Sub1

VM memory size fixes
Added script_output logic