### PR TITLE
Add vm flags

### DIFF
--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -60,6 +60,7 @@ pub fn transaction_batch_benchmark(c: &mut Criterion) {
             &mut idx_map,
             [0; 32],
             key,
+            VmFlags::default(),
         );
 
         let outputs: Vec<Output> = out_stack

--- a/benches/vm.rs
+++ b/benches/vm.rs
@@ -51,6 +51,10 @@ fn bench_coinbase(c: &mut Criterion) {
                 &mut idx_map,
                 [0; 32],
                 key,
+                VmFlags {
+                    build_stacktrace: false,
+                    validate_output_amounts: false,
+                },
             )
         })
     });
@@ -75,6 +79,10 @@ fn bench_coinbase(c: &mut Criterion) {
                             &mut idx_map,
                             [0; 32],
                             key,
+                            VmFlags {
+                                build_stacktrace: false,
+                                validate_output_amounts: false,
+                            },
                         )
                     })
                     .collect::<Vec<_>>()
@@ -102,6 +110,10 @@ fn bench_coinbase(c: &mut Criterion) {
                                 &mut idx_map,
                                 [0; 32],
                                 key,
+                                VmFlags {
+                                    build_stacktrace: false,
+                                    validate_output_amounts: false,
+                                },
                             )
                         })
                         .collect::<Vec<_>>()
@@ -166,7 +178,18 @@ fn bench_vm_abuse(c: &mut Criterion) {
                     let mut outs = vec![];
                     let mut idx_map = HashMap::new();
                     assert_eq!(
-                        ss.execute(&args, ins.as_slice(), &mut outs, &mut idx_map, [0; 32], key),
+                        ss.execute(
+                            &args,
+                            ins.as_slice(),
+                            &mut outs,
+                            &mut idx_map,
+                            [0; 32],
+                            key,
+                            VmFlags {
+                                build_stacktrace: false,
+                                validate_output_amounts: false
+                            }
+                        ),
                         Err((ExecutionResult::OutOfGas, StackTrace::default())).into()
                     );
                 });

--- a/src/node/mempool.rs
+++ b/src/node/mempool.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn append_batch() {
-        let txs: Vec<_> = (0..300).into_iter().map(|_| get_random_tx()).collect();
+        let txs: Vec<_> = (0..300).map(|_| get_random_tx()).collect();
 
         let mut mempool = Mempool::new();
 

--- a/src/primitives/transaction.rs
+++ b/src/primitives/transaction.rs
@@ -8,6 +8,7 @@ use crate::chain::{Shard, ShardBackend};
 use crate::consensus::Money;
 use crate::primitives::{Hash256, Input, Output};
 use crate::settings::SETTINGS;
+use crate::vm::VmFlags;
 use bincode::{Decode, Encode};
 use schnorrkel::{signing_context, verify_batch, PublicKey as SchnorPK, Signature as SchnorSig};
 use std::cmp::Ordering;
@@ -59,6 +60,10 @@ impl Transaction {
                 &mut idx_map,
                 [0; 32], // TODO: Inject seed here
                 &key,
+                VmFlags {
+                    validate_output_amounts: true,
+                    build_stacktrace: false,
+                },
             );
         }
 


### PR DESCRIPTION
Added vm flags such as `build_stacktrace` as we don't need to build stacktraces when validating transactions received over the wire but we do need it in tests and development.