### PR TITLE
Variable opcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Purplecoin uses the Green PoW model which lowers the energy consumption of minin
 Purplecoin uses 2 Proof of Work algorithms in tandem: RandomX and a choice out of several hash functions. One is suited to CPU mining and the other for ASIC miners. Algorithms are switched every Green PoW epoch.
 
 ## Donations
-While the development of Purplecoin initially happened in the sphere of Purple Technologies, it is not backed in any way by it or any other company. Purple Technologies is a for-profit company while Purplecoin is a decentralized project. Thereforce, the decisions and development happens at the community level. As such, the project also relies on the community at a funding level. 
+While the development of Purplecoin initially happened in the sphere of Purple Technologies, it is not backed in any way by it or any other company. Purple Technologies is a for-profit company while Purplecoin is a decentralized project. Therefore, the decisions and development happens at the community level. As such, the project also relies on the community at a funding level. 
 
 If you wish to support the development of Purplecoin, donations can be sent to the following BTC address:
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,16 +48,16 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0x21` Hash256Var - Pushes a `Hash256` onto the stack
     - [ ] OP `0x22` Hash512Var - Pushes a `Hash512` onto the stack
     - [x] OP `0x23` Unsigned8Var - Pushes an `Unsigned8` onto the stack
-    - [ ] OP `0x24` Unsigned16Var - Pushes an `Unsigned16` onto the stack
-    - [ ] OP `0x25` Unsigned32Var - Pushes an `Unsigned32` onto the stack
-    - [ ] OP `0x26` Unsigned64Var - Pushes an `Unsigned64` onto the stack
-    - [ ] OP `0x27` Unsigned128Var - Pushes an `Unsigned128` onto the stack
+    - [x] OP `0x24` Unsigned16Var - Pushes an `Unsigned16` onto the stack
+    - [x] OP `0x25` Unsigned32Var - Pushes an `Unsigned32` onto the stack
+    - [x] OP `0x26` Unsigned64Var - Pushes an `Unsigned64` onto the stack
+    - [x] OP `0x27` Unsigned128Var - Pushes an `Unsigned128` onto the stack
     - [ ] OP `0x28` UnsignedBigVar - Pushes an `UnsignedBig` onto the stack
-    - [ ] OP `0x29` Signed8Var - Pushes a `Signed8` onto the stack
-    - [ ] OP `0x2a` Signed16Var - Pushes a `Signed16` onto the stack
-    - [ ] OP `0x2b` Signed32Var - Pushes a `Signed32` onto the stack
-    - [ ] OP `0x2c` Signed64Var - Pushes a `Signed64` onto the stack
-    - [ ] OP `0x2d` Signed128Var - Pushes a `Signed128` onto the stack
+    - [x] OP `0x29` Signed8Var - Pushes a `Signed8` onto the stack
+    - [x] OP `0x2a` Signed16Var - Pushes a `Signed16` onto the stack
+    - [x] OP `0x2b` Signed32Var - Pushes a `Signed32` onto the stack
+    - [x] OP `0x2c` Signed64Var - Pushes a `Signed64` onto the stack
+    - [x] OP `0x2d` Signed128Var - Pushes a `Signed128` onto the stack
     - [ ] OP `0x2e` SignedBigVar - Pushes a `SignedBig` onto the stack
     - [ ] OP `0x31` Hash160ArrayVar - Pushes a `Hash160Array` onto the stack
     - [ ] OP `0x32` Hash256ArrayVar - Pushes a `Hash256Array` onto the stack

--- a/benches/vm.rs
+++ b/benches/vm.rs
@@ -284,7 +284,7 @@ fn bench_vm_load_var(c: &mut Criterion) {
     let inputs_hash = Hash160::hash_from_slice(ins_hashes.as_slice(), key);
     let inputs_hash: Hash160 = ins.iter().cloned().cycle().take(0).fold(
         inputs_hash.clone(),
-        |mut acc: Hash160, v: Input| {
+        |mut acc: Hash160, _v: Input| {
             let inputs_hashes = vec![acc.0, inputs_hash.0]
                 .iter()
                 .flatten()

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -324,7 +324,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned16Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 2] = [0; 2];
-                            
+
                             for j in 0..2 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -338,16 +338,23 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
-                                frame.stack.push(VmTerm::Unsigned16(u16::from_le_bytes(arr)));
+                                frame
+                                    .stack
+                                    .push(VmTerm::Unsigned16(u16::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                 frame.i_ptr += 1;
                                 memory_size += 2;
@@ -357,7 +364,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned32Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 4] = [0; 4];
-                            
+
                             for j in 0..4 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -371,16 +378,23 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
-                                frame.stack.push(VmTerm::Unsigned32(u32::from_le_bytes(arr)));
+                                frame
+                                    .stack
+                                    .push(VmTerm::Unsigned32(u32::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                 frame.i_ptr += 1;
                                 memory_size += 4;
@@ -390,7 +404,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned64Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 8] = [0; 8];
-                            
+
                             for j in 0..8 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -404,16 +418,23 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
-                                frame.stack.push(VmTerm::Unsigned64(u64::from_le_bytes(arr)));
+                                frame
+                                    .stack
+                                    .push(VmTerm::Unsigned64(u64::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                 frame.i_ptr += 1;
                                 memory_size += 8;
@@ -423,7 +444,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned128Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 16] = [0; 16];
-                            
+
                             for j in 0..16 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -437,16 +458,23 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
-                                frame.stack.push(VmTerm::Unsigned128(u128::from_le_bytes(arr)));
+                                frame
+                                    .stack
+                                    .push(VmTerm::Unsigned128(u128::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                 frame.i_ptr += 1;
                                 memory_size += 16;
@@ -459,7 +487,9 @@ impl Script {
 
                             match i {
                                 ScriptEntry::Byte(byte) => {
-                                    frame.stack.push(VmTerm::Signed8(i8::from_le_bytes([*byte])));
+                                    frame
+                                        .stack
+                                        .push(VmTerm::Signed8(i8::from_le_bytes([*byte])));
                                     frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                     frame.i_ptr += 1;
                                     memory_size += 1;
@@ -478,7 +508,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed16Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 2] = [0; 2];
-                            
+
                             for j in 0..2 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -492,14 +522,19 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
                                 frame.stack.push(VmTerm::Signed16(i16::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
@@ -511,7 +546,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed32Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 4] = [0; 4];
-                            
+
                             for j in 0..4 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -525,14 +560,19 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
                                 frame.stack.push(VmTerm::Signed32(i32::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
@@ -544,7 +584,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed64Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 8] = [0; 8];
-                            
+
                             for j in 0..8 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -558,14 +598,19 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
                                 frame.stack.push(VmTerm::Signed64(i64::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
@@ -577,7 +622,7 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed128Var) => {
                             let mut failed = false;
                             let mut arr: [u8; 16] = [0; 16];
-                            
+
                             for j in 0..16 {
                                 frame.i_ptr += 1;
                                 let i = &f.script[frame.i_ptr];
@@ -591,16 +636,23 @@ impl Script {
                                         failed = true;
                                         frame.executor.state = ScriptExecutorState::Error(
                                             ExecutionResult::BadFormat,
-                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            (
+                                                frame.i_ptr,
+                                                frame.func_idx,
+                                                *op,
+                                                frame.stack.as_slice(),
+                                            )
                                                 .into(),
                                         );
                                         break;
                                     }
                                 }
-                            }                            
-                            
+                            }
+
                             if !failed {
-                                frame.stack.push(VmTerm::Signed128(i128::from_le_bytes(arr)));
+                                frame
+                                    .stack
+                                    .push(VmTerm::Signed128(i128::from_le_bytes(arr)));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                 frame.i_ptr += 1;
                                 memory_size += 16;
@@ -1557,7 +1609,8 @@ impl<'a> ScriptExecutor<'a> {
                 }
 
                 ScriptEntry::Opcode(OP::Unsigned128Var) => {
-                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned128Var);
+                    self.state =
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned128Var);
                 }
 
                 ScriptEntry::Opcode(OP::Signed8Var) => {
@@ -4159,7 +4212,6 @@ mod tests {
         assert_eq!(outs, base.out);
     }
 
-
     #[test]
     fn it_loads_unsigned_64var() {
         let key = "test_key";
@@ -4398,7 +4450,6 @@ mod tests {
         );
         assert_eq!(outs, base.out);
     }
-
 
     #[test]
     fn it_loads_signed_64var() {

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -58,7 +58,7 @@ macro_rules! check_top_stack_val {
 }
 
 macro_rules! var_load {
-    ($frame:expr, $script:expr, $sum:ident, $type:ty, $step:expr) => { 
+    ($frame:expr, $script:expr, $sum:ident, $type:ty, $step:expr) => {
         $frame.i_ptr += 1;
         if let ScriptEntry::Byte(byte) = $script.script[$frame.i_ptr] {
             $sum += (byte as $type);
@@ -324,7 +324,7 @@ impl Script {
 
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned8Var) => {
                             frame.i_ptr += 1;
-                         
+
                             if let ScriptEntry::Byte(byte) = &f.script[frame.i_ptr] {
                                 frame.stack.push(VmTerm::Unsigned8(*byte));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
@@ -371,7 +371,10 @@ impl Script {
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned128Var) => {
                             let mut sum: u128 = 0;
 
-                            var_load!(frame, f, sum, u128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0);
+                            var_load!(
+                                frame, f, sum, u128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40,
+                                32, 24, 16, 8, 0
+                            );
 
                             frame.stack.push(VmTerm::Unsigned128(sum));
                             frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
@@ -381,11 +384,9 @@ impl Script {
 
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed8Var) => {
                             frame.i_ptr += 1;
-                         
+
                             if let ScriptEntry::Byte(byte) = &f.script[frame.i_ptr] {
-                                let byte = unsafe {
-                                    mem::transmute::<u8, i8>(*byte)
-                                };
+                                let byte = unsafe { mem::transmute::<u8, i8>(*byte) };
                                 frame.stack.push(VmTerm::Signed8(byte));
                                 frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                                 frame.i_ptr += 1;
@@ -400,9 +401,7 @@ impl Script {
 
                             var_load!(frame, f, sum, u16, 8, 0);
 
-                            let sum = unsafe {
-                                mem::transmute::<u16, i16>(sum)
-                            };
+                            let sum = unsafe { mem::transmute::<u16, i16>(sum) };
                             frame.stack.push(VmTerm::Signed16(sum));
                             frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                             frame.i_ptr += 1;
@@ -414,9 +413,7 @@ impl Script {
 
                             var_load!(frame, f, sum, u32, 24, 16, 8, 0);
 
-                            let sum = unsafe {
-                                mem::transmute::<u32, i32>(sum)
-                            };
+                            let sum = unsafe { mem::transmute::<u32, i32>(sum) };
                             frame.stack.push(VmTerm::Signed32(sum));
                             frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                             frame.i_ptr += 1;
@@ -428,23 +425,22 @@ impl Script {
 
                             var_load!(frame, f, sum, u64, 56, 48, 40, 32, 24, 16, 8, 0);
 
-                            let sum = unsafe {
-                                mem::transmute::<u64, i64>(sum)
-                            };
+                            let sum = unsafe { mem::transmute::<u64, i64>(sum) };
                             frame.stack.push(VmTerm::Signed64(sum));
                             frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                             frame.i_ptr += 1;
                             memory_size += 8;
-                    }
+                        }
 
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed128Var) => {
                             let mut sum: u128 = 0;
 
-                            var_load!(frame, f, sum, u128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0);
-                            
-                            let sum = unsafe {
-                                mem::transmute::<u128, i128>(sum)
-                            };
+                            var_load!(
+                                frame, f, sum, u128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40,
+                                32, 24, 16, 8, 0
+                            );
+
+                            let sum = unsafe { mem::transmute::<u128, i128>(sum) };
                             frame.stack.push(VmTerm::Signed128(sum));
                             frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
                             frame.i_ptr += 1;

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -321,6 +321,292 @@ impl Script {
                             }
                         }
 
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned16Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 2] = [0; 2];
+                            
+                            for j in 0..2 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Unsigned16(u16::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 2;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned32Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 4] = [0; 4];
+                            
+                            for j in 0..4 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Unsigned32(u32::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 4;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned64Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 8] = [0; 8];
+                            
+                            for j in 0..8 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Unsigned64(u64::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 8;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned128Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 16] = [0; 16];
+                            
+                            for j in 0..16 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Unsigned128(u128::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 16;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed8Var) => {
+                            frame.i_ptr += 1;
+                            let i = &f.script[frame.i_ptr];
+
+                            match i {
+                                ScriptEntry::Byte(byte) => {
+                                    frame.stack.push(VmTerm::Signed8(i8::from_le_bytes([*byte])));
+                                    frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                    frame.i_ptr += 1;
+                                    memory_size += 1;
+                                }
+
+                                ScriptEntry::Opcode(op) => {
+                                    frame.executor.state = ScriptExecutorState::Error(
+                                        ExecutionResult::BadFormat,
+                                        (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                            .into(),
+                                    );
+                                }
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed16Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 2] = [0; 2];
+                            
+                            for j in 0..2 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Signed16(i16::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 2;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed32Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 4] = [0; 4];
+                            
+                            for j in 0..4 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Signed32(i32::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 4;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed64Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 8] = [0; 8];
+                            
+                            for j in 0..8 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Signed64(i64::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 8;
+                            }
+                        }
+
+                        ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed128Var) => {
+                            let mut failed = false;
+                            let mut arr: [u8; 16] = [0; 16];
+                            
+                            for j in 0..16 {
+                                frame.i_ptr += 1;
+                                let i = &f.script[frame.i_ptr];
+
+                                match i {
+                                    ScriptEntry::Byte(byte) => {
+                                        arr[j] = *byte;
+                                    }
+
+                                    ScriptEntry::Opcode(op) => {
+                                        failed = true;
+                                        frame.executor.state = ScriptExecutorState::Error(
+                                            ExecutionResult::BadFormat,
+                                            (frame.i_ptr, frame.func_idx, *op, frame.stack.as_slice())
+                                                .into(),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }                            
+                            
+                            if !failed {
+                                frame.stack.push(VmTerm::Signed128(i128::from_le_bytes(arr)));
+                                frame.executor.state = ScriptExecutorState::ExpectingInitialOP;
+                                frame.i_ptr += 1;
+                                memory_size += 16;
+                            }
+                        }
+
                         // Extend stack trace
                         ScriptExecutorState::Error(err, stack_trace) => {
                             let mut stack_trace = stack_trace.clone();
@@ -1256,6 +1542,42 @@ impl<'a> ScriptExecutor<'a> {
 
                 ScriptEntry::Opcode(OP::Unsigned8Var) => {
                     self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned8Var);
+                }
+
+                ScriptEntry::Opcode(OP::Unsigned16Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned16Var);
+                }
+
+                ScriptEntry::Opcode(OP::Unsigned32Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned32Var);
+                }
+
+                ScriptEntry::Opcode(OP::Unsigned64Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned64Var);
+                }
+
+                ScriptEntry::Opcode(OP::Unsigned128Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Unsigned128Var);
+                }
+
+                ScriptEntry::Opcode(OP::Signed8Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed8Var);
+                }
+
+                ScriptEntry::Opcode(OP::Signed16Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed16Var);
+                }
+
+                ScriptEntry::Opcode(OP::Signed32Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed32Var);
+                }
+
+                ScriptEntry::Opcode(OP::Signed64Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed64Var);
+                }
+
+                ScriptEntry::Opcode(OP::Signed128Var) => {
+                    self.state = ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::Signed128Var);
                 }
 
                 ScriptEntry::Opcode(OP::Add1) => {
@@ -3733,5 +4055,485 @@ mod tests {
             ),
             Err((ExecutionResult::InvalidArgs, StackTrace::default())).into()
         );
+    }
+
+    #[test]
+    fn it_loads_unsigned_16var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned16(0x0011),
+            VmTerm::Unsigned16(0x2301),
+            VmTerm::Unsigned16(0x0123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_loads_unsigned_32var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned32Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned32Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned32Var),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned32(0x00000011),
+            VmTerm::Unsigned32(0x00002301),
+            VmTerm::Unsigned32(0x00000123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+
+    #[test]
+    fn it_loads_unsigned_64var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned64Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned64Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned64Var),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned64(0x0000000000000011),
+            VmTerm::Unsigned64(0x0123000000002301),
+            VmTerm::Unsigned64(0x0123000000000123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_loads_unsigned_128var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned128Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Opcode(OP::Unsigned128Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x22),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned128(0x22000000000000000123000000002301),
+            VmTerm::Unsigned128(0x11000000000000000123000000000123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_loads_signed_16var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Signed16Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Signed16Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Opcode(OP::Signed16Var),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Signed16(0x0011),
+            VmTerm::Signed16(0x2301),
+            VmTerm::Signed16(0x0123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_loads_signed_32var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Signed32Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Signed32Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Signed32Var),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Signed32(0x00000011),
+            VmTerm::Signed32(0x00002301),
+            VmTerm::Signed32(0x00000123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+
+    #[test]
+    fn it_loads_signed_64var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Signed64Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Signed64Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Signed64Var),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Signed64(0x0000000000000011),
+            VmTerm::Signed64(0x0123000000002301),
+            VmTerm::Signed64(0x0123000000000123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_loads_signed_128var() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Signed128Var),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x11),
+                ScriptEntry::Opcode(OP::Signed128Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x23),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Byte(0x22),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Signed128(0x22000000000000000123000000002301),
+            VmTerm::Signed128(0x11000000000000000123000000000123),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
     }
 }


### PR DESCRIPTION
Added opcodes implementation for:

- [x] OP 0x24 Unsigned16Var - Pushes an Unsigned16 onto the stack
- [x] OP 0x25 Unsigned32Var - Pushes an Unsigned32 onto the stack
- [x] OP 0x26 Unsigned64Var - Pushes an Unsigned64 onto the stack
- [x] OP 0x27 Unsigned128Var - Pushes an Unsigned128 onto the stack
- [x] OP 0x29 Signed8Var - Pushes a Signed8 onto the stack
- [x] OP 0x2a Signed16Var - Pushes a Signed16 onto the stack
- [x] OP 0x2b Signed32Var - Pushes a Signed32 onto the stack
- [x] OP 0x2c Signed64Var - Pushes a Signed64 onto the stack
- [x] OP 0x2d Signed128Var - Pushes a Signed128 onto the stack