### PR TITLE
Comparison fixes and OpCodes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,7 +74,7 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [x] OP `0x3d` Signed64ArrayVar - Pushes a `Signed64Array` onto the stack
     - [x] OP `0x3e` Signed128ArrayVar - Pushes a `Signed128Array` onto the stack
     - [ ] OP `0x3f` SignedBigArrayVar - Pushes a `SignedBigArray` onto the stack
-    - [ ] OP `0x4a` ArrayLen - Pushes on top of the stack the len of the array currently on top of the stack
+    - [x] OP `0x4a` ArrayLen - Pushes on top of the stack the len of the array currently on top of the stack
     - [x] OP `0x4b` GetType - Pushes on top of the stack the type code of the value currently on top of the stack as a `Unsigned8`
     - [x] OP `0x4f` ClearStack - Clears the stack
     - [ ] OP `0x50` Add - Pops the two topmost items on the stack, performs addition and pushes the result on the stack

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,10 +155,10 @@ This document presents the technical roadmap of the Purplecoin project. Please n
     - [ ] OP `0xb8` ReturnFunc - Returns from the current function and moves the terms on the current frame to the parent frame. Behaves the same as `Return` if called from the main function
     - [ ] OP `0xb9` Return - Stops script execution and succeeds if the topmost item on the stack is `1`
     - [ ] OP `0xba` EqVerify - Pushes the current output's binary format to the signature verification stack and stops script execution if the two topmost items on the stack are equal
-    - [ ] OP `0xbb` Lt - Pushes `1` on top of the stack if the topmost item on the stack is less than the second item on stack
-    - [ ] OP `0xbc` Gt - Pushes `1` on top of the stack if the topmost item on the stack is greater than the second item on stack
-    - [ ] OP `0xbd` Leq - Pushes `1` on top of the stack if the topmost item on the stack is less or equal than the second item on stack
-    - [ ] OP `0xbe` Geq - Pushes `1` on top of the stack if the topmost item on the stack is greater or equal than the second item on stack
+    - [x] OP `0xbb` Lt - Pushes `1` on top of the stack if the topmost item on the stack is less than the second item on stack
+    - [x] OP `0xbc` Gt - Pushes `1` on top of the stack if the topmost item on the stack is greater than the second item on stack
+    - [x] OP `0xbd` Leq - Pushes `1` on top of the stack if the topmost item on the stack is less or equal than the second item on stack
+    - [x] OP `0xbe` Geq - Pushes `1` on top of the stack if the topmost item on the stack is greater or equal than the second item on stack
     - [ ] OP `0xbf` IfLt - If less than control operator
     - [ ] OP `0xc0` IfGt - If greater than control operator
     - [ ] OP `0xc1` IfLeq - If less or equal control operator

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -303,6 +303,7 @@ impl VmTerm {
         }
     }
 
+    /// Checks if the value of the term equals to 0
     pub fn equals_0(&self) -> bool {
         match self {
             Self::Hash160(val) => *val == ZERO_HASH160,
@@ -338,6 +339,7 @@ impl VmTerm {
         }
     }
 
+    /// Checks if the value of the term equals to 1
     pub fn equals_1(&self) -> bool {
         match self {
             Self::Hash160(val) => {
@@ -394,6 +396,79 @@ impl VmTerm {
             Self::Signed64Array(val) => check_array_values!(*val, 1_i64),
             Self::Signed128Array(val) => check_array_values!(*val, 1_i128),
             Self::SignedBigArray(val) => check_array_values!(*val, ibig!(1)),
+        }
+    }
+
+    /// Checks if the two terms are the same. Used as pre-check for comparison operations
+    pub fn is_same(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Hash160(_), Self::Hash160(_)) => true,
+            (Self::Hash256(_), Self::Hash256(_)) => true,
+            (Self::Hash512(_), Self::Hash512(_)) => true,
+            (Self::Unsigned8(_), Self::Unsigned8(_)) => true,
+            (Self::Unsigned16(_), Self::Unsigned16(_)) => true,
+            (Self::Unsigned32(_), Self::Unsigned32(_)) => true,
+            (Self::Unsigned64(_), Self::Unsigned64(_)) => true,
+            (Self::Unsigned128(_), Self::Unsigned128(_)) => true,
+            (Self::UnsignedBig(_), Self::UnsignedBig(_)) => true,
+            (Self::Signed8(_), Self::Signed8(_)) => true,
+            (Self::Signed16(_), Self::Signed16(_)) => true,
+            (Self::Signed32(_), Self::Signed32(_)) => true,
+            (Self::Signed64(_), Self::Signed64(_)) => true,
+            (Self::Signed128(_), Self::Signed128(_)) => true,
+            (Self::SignedBig(_), Self::SignedBig(_)) => true,
+            (Self::Hash160Array(arr1), Self::Hash160Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Hash256Array(arr1), Self::Hash256Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Hash512Array(arr1), Self::Hash512Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Unsigned8Array(arr1), Self::Unsigned8Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Unsigned16Array(arr1), Self::Unsigned16Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Unsigned32Array(arr1), Self::Unsigned32Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Unsigned64Array(arr1), Self::Unsigned64Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Unsigned128Array(arr1), Self::Unsigned128Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::UnsignedBigArray(arr1), Self::UnsignedBigArray(arr2)) => arr1.len() == arr2.len(),
+            (Self::Signed8Array(arr1), Self::Signed8Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Signed16Array(arr1), Self::Signed16Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Signed32Array(arr1), Self::Signed32Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Signed64Array(arr1), Self::Signed64Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::Signed128Array(arr1), Self::Signed128Array(arr2)) => arr1.len() == arr2.len(),
+            (Self::SignedBigArray(arr1), Self::SignedBigArray(arr2)) => arr1.len() == arr2.len(),
+            _ => false
+        }
+    }
+
+    /// Checks if the term is an array type
+    pub fn is_array(&self) -> bool {
+        match self {
+            Self::Hash160(_) => false,
+            Self::Hash256(_) => false,
+            Self::Hash512(_) => false,
+            Self::Unsigned8(_) => false,
+            Self::Unsigned16(_) => false,
+            Self::Unsigned32(_) => false,
+            Self::Unsigned64(_) => false,
+            Self::Unsigned128(_) => false,
+            Self::UnsignedBig(_) => false,
+            Self::Signed8(_) => false,
+            Self::Signed16(_) => false,
+            Self::Signed32(_) => false,
+            Self::Signed64(_) => false,
+            Self::Signed128(_) => false,
+            Self::SignedBig(_) => false,
+            Self::Hash160Array(_) => true,
+            Self::Hash256Array(_) => true,
+            Self::Hash512Array(_) => true,
+            Self::Unsigned8Array(_) => true,
+            Self::Unsigned16Array(_) => true,
+            Self::Unsigned32Array(_) => true,
+            Self::Unsigned64Array(_) => true,
+            Self::Unsigned128Array(_) => true,
+            Self::UnsignedBigArray(_) => true,
+            Self::Signed8Array(_) => true,
+            Self::Signed16Array(_) => true,
+            Self::Signed32Array(_) => true,
+            Self::Signed64Array(_) => true,
+            Self::Signed128Array(_) => true,
+            Self::SignedBigArray(_) => true,
         }
     }
 }
@@ -1093,5 +1168,112 @@ mod tests {
         assert!(!VmTerm::Signed64Array(vec![1, 1, 1, 1, 1, 1, 1, 1, 0]).equals_1());
         assert!(!VmTerm::Signed128Array(vec![1, 1, 1, 1, 1, 1, 0, 1]).equals_1());
         assert!(!VmTerm::SignedBigArray(vec![ibig!(1), ibig!(1), ibig!(0)]).equals_1());
+    }
+
+    #[test]
+    fn test_is_same() {
+        assert!(VmTerm::Hash160([1; 20]).is_same(&VmTerm::Hash160([2; 20])));
+        assert!(VmTerm::Hash256([1; 32]).is_same(&VmTerm::Hash256([2; 32])));
+        assert!(VmTerm::Hash512([1; 64]).is_same(&VmTerm::Hash512([2; 64])));
+        assert!(VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Unsigned8(2_u8)));
+        assert!(VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Unsigned16(2_u16)));
+        assert!(VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Unsigned32(2_u32)));
+        assert!(VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Unsigned64(2_u64)));
+        assert!(VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Unsigned128(2_u128)));
+        assert!(VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::UnsignedBig(ubig!(2))));
+        assert!(VmTerm::Signed8(1_i8).is_same(&VmTerm::Signed8(2_i8)));
+        assert!(VmTerm::Signed16(1_i16).is_same(&VmTerm::Signed16(2_i16)));
+        assert!(VmTerm::Signed32(1_i32).is_same(&VmTerm::Signed32(2_i32)));
+        assert!(VmTerm::Signed64(1_i64).is_same(&VmTerm::Signed64(2_i64)));
+        assert!(VmTerm::Signed128(1_i128).is_same(&VmTerm::Signed128(2_i128)));
+        assert!(VmTerm::SignedBig(ibig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
+
+        assert!(VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20])).is_same(&VmTerm::Hash160Array(vec!([2; 20], [2; 20], [2; 20]))));
+        assert!(VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32])).is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32], [2; 32]))));
+        assert!(VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64])).is_same(&VmTerm::Hash512Array(vec!([2; 64], [2; 64], [2; 64]))));
+        assert!(VmTerm::Unsigned8Array(vec!(1_u8, 1_u8)).is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
+        assert!(VmTerm::Unsigned16Array(vec!(1_u16, 1_u16)).is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
+        assert!(VmTerm::Unsigned32Array(vec!(1_u32, 1_u32)).is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
+        assert!(VmTerm::Unsigned64Array(vec!(1_u64, 1_u64)).is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
+        assert!(VmTerm::Unsigned128Array(vec!(1_u128, 1_u128)).is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
+        assert!(VmTerm::UnsignedBigArray(vec!(ubig!(1), ubig!(1))).is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
+        assert!(VmTerm::Signed8Array(vec!(1_i8, 1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
+        assert!(VmTerm::Signed16Array(vec!(1_i16, 1_i16)).is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
+        assert!(VmTerm::Signed32Array(vec!(1_i32, 1_i32)).is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
+        assert!(VmTerm::Signed64Array(vec!(1_i64, 1_i64)).is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
+        assert!(VmTerm::Signed128Array(vec!(1_i128, 1_i128)).is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
+        assert!(VmTerm::SignedBigArray(vec!(ibig!(1), ibig!(1))).is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
+
+        assert!(!VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20])).is_same(&VmTerm::Hash160Array(vec!([2; 20]))));
+        assert!(!VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32])).is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32]))));
+        assert!(!VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64])).is_same(&VmTerm::Hash512Array(vec!([2; 64]))));
+        assert!(!VmTerm::Unsigned8Array(vec!(1_u8)).is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
+        assert!(!VmTerm::Unsigned16Array(vec!(1_u16)).is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
+        assert!(!VmTerm::Unsigned32Array(vec!(1_u32)).is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
+        assert!(!VmTerm::Unsigned64Array(vec!(1_u64)).is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
+        assert!(!VmTerm::Unsigned128Array(vec!( 1_u128)).is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
+        assert!(!VmTerm::UnsignedBigArray(vec!(ubig!(1))).is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
+        assert!(!VmTerm::Signed8Array(vec!(1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
+        assert!(!VmTerm::Signed16Array(vec!(1_i16)).is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
+        assert!(!VmTerm::Signed32Array(vec!(1_i32)).is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
+        assert!(!VmTerm::Signed64Array(vec!(1_i64)).is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
+        assert!(!VmTerm::Signed128Array(vec!(1_i128)).is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
+        assert!(!VmTerm::SignedBigArray(vec!(ibig!(1))).is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
+
+        assert!(!VmTerm::Hash160([1; 20]).is_same(&VmTerm::Hash256([2; 32])));
+        assert!(!VmTerm::Hash256([1; 32]).is_same(&VmTerm::Hash512([2; 64])));
+        assert!(!VmTerm::Hash512([1; 64]).is_same(&VmTerm::Hash160([2; 20])));
+        assert!(!VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Unsigned16(2_u16)));
+        assert!(!VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Unsigned32(2_u32)));
+        assert!(!VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Unsigned64(2_u64)));
+        assert!(!VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Unsigned128(2_u128)));
+        assert!(!VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Unsigned8(2_u8)));
+        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
+        assert!(!VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Signed8(2_i8)));
+        assert!(!VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Signed16(2_i16)));
+        assert!(!VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Signed32(2_i32)));
+        assert!(!VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Signed64(2_i64)));
+        assert!(!VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Signed128(2_i128)));
+        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
+        assert!(!VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Signed128(2_i128)));
+        assert!(!VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Signed64(2_i64)));
+        assert!(!VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Signed32(2_i32)));
+        assert!(!VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Signed64(2_i64)));
+        assert!(!VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Signed128(2_i128)));
+        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
+    }
+
+    #[test]
+    fn test_is_array() {
+        assert!(!VmTerm::Hash160([0; 20]).is_array());
+        assert!(!VmTerm::Hash256([0; 32]).is_array());
+        assert!(!VmTerm::Hash512([0; 64]).is_array());
+        assert!(!VmTerm::Unsigned8(0).is_array());
+        assert!(!VmTerm::Unsigned16(0).is_array());
+        assert!(!VmTerm::Unsigned32(0).is_array());
+        assert!(!VmTerm::Unsigned64(0).is_array());
+        assert!(!VmTerm::Unsigned128(0).is_array());
+        assert!(!VmTerm::UnsignedBig(ubig!(0)).is_array());
+        assert!(!VmTerm::Signed8(0).is_array());
+        assert!(!VmTerm::Signed16(0).is_array());
+        assert!(!VmTerm::Signed32(0).is_array());
+        assert!(!VmTerm::Signed64(0).is_array());
+        assert!(!VmTerm::Signed128(0).is_array());
+        assert!(!VmTerm::SignedBig(ibig!(0)).is_array());
+        assert!(VmTerm::Hash160Array(vec![[0; 20], [0; 20], [0; 20]]).is_array());
+        assert!(VmTerm::Hash256Array(vec![[0; 32], [0; 32], [0; 32], [0; 32]]).is_array());
+        assert!(VmTerm::Hash512Array(vec![[0; 64], [0; 64], [0; 64], [0; 64], [0; 64]]).is_array());
+        assert!(VmTerm::Unsigned8Array(vec![0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Unsigned16Array(vec![0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Unsigned32Array(vec![0, 0, 0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Unsigned64Array(vec![0, 0, 0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Unsigned128Array(vec![0, 0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::UnsignedBigArray(vec![ubig!(0), ubig!(0), ubig!(0)]).is_array());
+        assert!(VmTerm::Signed8Array(vec![0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Signed16Array(vec![0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Signed32Array(vec![0, 0, 0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Signed64Array(vec![0, 0, 0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::Signed128Array(vec![0, 0, 0, 0, 0, 0, 0, 0]).is_array());
+        assert!(VmTerm::SignedBigArray(vec![ibig!(0), ibig!(0), ibig!(0)]).is_array());
     }
 }

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -471,6 +471,28 @@ impl VmTerm {
             Self::SignedBigArray(_) => true,
         }
     }
+
+    /// Returns the length if the VmTerm is an array type, 0 otherwise
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Hash160Array(arr) => arr.len(),
+            Self::Hash256Array(arr) => arr.len(),
+            Self::Hash512Array(arr) => arr.len(),
+            Self::Unsigned8Array(arr) => arr.len(),
+            Self::Unsigned16Array(arr) => arr.len(),
+            Self::Unsigned32Array(arr) => arr.len(),
+            Self::Unsigned64Array(arr) => arr.len(),
+            Self::Unsigned128Array(arr) => arr.len(),
+            Self::UnsignedBigArray(arr) => arr.len(),
+            Self::Signed8Array(arr) => arr.len(),
+            Self::Signed16Array(arr) => arr.len(),
+            Self::Signed32Array(arr) => arr.len(),
+            Self::Signed64Array(arr) => arr.len(),
+            Self::Signed128Array(arr) => arr.len(),
+            Self::SignedBigArray(arr) => arr.len(),
+            _ => 0
+        }
+    }
 }
 
 impl Encode for VmTerm {

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -399,8 +399,8 @@ impl VmTerm {
         }
     }
 
-    /// Checks if the two terms are the same. Used as pre-check for comparison operations
-    pub fn is_same(&self, other: &Self) -> bool {
+    /// Checks if the two terms are comparable
+    pub fn is_comparable(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Hash160(_), Self::Hash160(_)) => true,
             (Self::Hash256(_), Self::Hash256(_)) => true,
@@ -1197,110 +1197,110 @@ mod tests {
     }
 
     #[test]
-    fn test_is_same() {
-        assert!(VmTerm::Hash160([1; 20]).is_same(&VmTerm::Hash160([2; 20])));
-        assert!(VmTerm::Hash256([1; 32]).is_same(&VmTerm::Hash256([2; 32])));
-        assert!(VmTerm::Hash512([1; 64]).is_same(&VmTerm::Hash512([2; 64])));
-        assert!(VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Unsigned8(2_u8)));
-        assert!(VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Unsigned16(2_u16)));
-        assert!(VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Unsigned32(2_u32)));
-        assert!(VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Unsigned64(2_u64)));
-        assert!(VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Unsigned128(2_u128)));
-        assert!(VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::UnsignedBig(ubig!(2))));
-        assert!(VmTerm::Signed8(1_i8).is_same(&VmTerm::Signed8(2_i8)));
-        assert!(VmTerm::Signed16(1_i16).is_same(&VmTerm::Signed16(2_i16)));
-        assert!(VmTerm::Signed32(1_i32).is_same(&VmTerm::Signed32(2_i32)));
-        assert!(VmTerm::Signed64(1_i64).is_same(&VmTerm::Signed64(2_i64)));
-        assert!(VmTerm::Signed128(1_i128).is_same(&VmTerm::Signed128(2_i128)));
-        assert!(VmTerm::SignedBig(ibig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
+    fn test_is_comparable() {
+        assert!(VmTerm::Hash160([1; 20]).is_comparable(&VmTerm::Hash160([2; 20])));
+        assert!(VmTerm::Hash256([1; 32]).is_comparable(&VmTerm::Hash256([2; 32])));
+        assert!(VmTerm::Hash512([1; 64]).is_comparable(&VmTerm::Hash512([2; 64])));
+        assert!(VmTerm::Unsigned8(1_u8).is_comparable(&VmTerm::Unsigned8(2_u8)));
+        assert!(VmTerm::Unsigned16(1_u16).is_comparable(&VmTerm::Unsigned16(2_u16)));
+        assert!(VmTerm::Unsigned32(1_u32).is_comparable(&VmTerm::Unsigned32(2_u32)));
+        assert!(VmTerm::Unsigned64(1_u64).is_comparable(&VmTerm::Unsigned64(2_u64)));
+        assert!(VmTerm::Unsigned128(1_u128).is_comparable(&VmTerm::Unsigned128(2_u128)));
+        assert!(VmTerm::UnsignedBig(ubig!(1)).is_comparable(&VmTerm::UnsignedBig(ubig!(2))));
+        assert!(VmTerm::Signed8(1_i8).is_comparable(&VmTerm::Signed8(2_i8)));
+        assert!(VmTerm::Signed16(1_i16).is_comparable(&VmTerm::Signed16(2_i16)));
+        assert!(VmTerm::Signed32(1_i32).is_comparable(&VmTerm::Signed32(2_i32)));
+        assert!(VmTerm::Signed64(1_i64).is_comparable(&VmTerm::Signed64(2_i64)));
+        assert!(VmTerm::Signed128(1_i128).is_comparable(&VmTerm::Signed128(2_i128)));
+        assert!(VmTerm::SignedBig(ibig!(1)).is_comparable(&VmTerm::SignedBig(ibig!(2))));
 
         assert!(VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20]))
-            .is_same(&VmTerm::Hash160Array(vec!([2; 20], [2; 20], [2; 20]))));
+            .is_comparable(&VmTerm::Hash160Array(vec!([2; 20], [2; 20], [2; 20]))));
         assert!(VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32]))
-            .is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32], [2; 32]))));
+            .is_comparable(&VmTerm::Hash256Array(vec!([2; 32], [2; 32], [2; 32]))));
         assert!(VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64]))
-            .is_same(&VmTerm::Hash512Array(vec!([2; 64], [2; 64], [2; 64]))));
+            .is_comparable(&VmTerm::Hash512Array(vec!([2; 64], [2; 64], [2; 64]))));
         assert!(VmTerm::Unsigned8Array(vec!(1_u8, 1_u8))
-            .is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
+            .is_comparable(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
         assert!(VmTerm::Unsigned16Array(vec!(1_u16, 1_u16))
-            .is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
+            .is_comparable(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
         assert!(VmTerm::Unsigned32Array(vec!(1_u32, 1_u32))
-            .is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
+            .is_comparable(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
         assert!(VmTerm::Unsigned64Array(vec!(1_u64, 1_u64))
-            .is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
+            .is_comparable(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
         assert!(VmTerm::Unsigned128Array(vec!(1_u128, 1_u128))
-            .is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
+            .is_comparable(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
         assert!(VmTerm::UnsignedBigArray(vec!(ubig!(1), ubig!(1)))
-            .is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
+            .is_comparable(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
         assert!(
-            VmTerm::Signed8Array(vec!(1_i8, 1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8)))
+            VmTerm::Signed8Array(vec!(1_i8, 1_i8)).is_comparable(&VmTerm::Signed8Array(vec!(2_i8, 2_i8)))
         );
         assert!(VmTerm::Signed16Array(vec!(1_i16, 1_i16))
-            .is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
+            .is_comparable(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
         assert!(VmTerm::Signed32Array(vec!(1_i32, 1_i32))
-            .is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
+            .is_comparable(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
         assert!(VmTerm::Signed64Array(vec!(1_i64, 1_i64))
-            .is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
+            .is_comparable(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
         assert!(VmTerm::Signed128Array(vec!(1_i128, 1_i128))
-            .is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
+            .is_comparable(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
         assert!(VmTerm::SignedBigArray(vec!(ibig!(1), ibig!(1)))
-            .is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
+            .is_comparable(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
 
         assert!(!VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20]))
-            .is_same(&VmTerm::Hash160Array(vec!([2; 20]))));
+            .is_comparable(&VmTerm::Hash160Array(vec!([2; 20]))));
         assert!(!VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32]))
-            .is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32]))));
+            .is_comparable(&VmTerm::Hash256Array(vec!([2; 32], [2; 32]))));
         assert!(!VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64]))
-            .is_same(&VmTerm::Hash512Array(vec!([2; 64]))));
+            .is_comparable(&VmTerm::Hash512Array(vec!([2; 64]))));
         assert!(
-            !VmTerm::Unsigned8Array(vec!(1_u8)).is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8)))
+            !VmTerm::Unsigned8Array(vec!(1_u8)).is_comparable(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8)))
         );
         assert!(!VmTerm::Unsigned16Array(vec!(1_u16))
-            .is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
+            .is_comparable(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
         assert!(!VmTerm::Unsigned32Array(vec!(1_u32))
-            .is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
+            .is_comparable(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
         assert!(!VmTerm::Unsigned64Array(vec!(1_u64))
-            .is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
+            .is_comparable(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
         assert!(!VmTerm::Unsigned128Array(vec!(1_u128))
-            .is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
+            .is_comparable(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
         assert!(!VmTerm::UnsignedBigArray(vec!(ubig!(1)))
-            .is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
-        assert!(!VmTerm::Signed8Array(vec!(1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
+            .is_comparable(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
+        assert!(!VmTerm::Signed8Array(vec!(1_i8)).is_comparable(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
         assert!(
-            !VmTerm::Signed16Array(vec!(1_i16)).is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16)))
+            !VmTerm::Signed16Array(vec!(1_i16)).is_comparable(&VmTerm::Signed16Array(vec!(2_i16, 2_i16)))
         );
         assert!(
-            !VmTerm::Signed32Array(vec!(1_i32)).is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32)))
+            !VmTerm::Signed32Array(vec!(1_i32)).is_comparable(&VmTerm::Signed32Array(vec!(2_i32, 2_i32)))
         );
         assert!(
-            !VmTerm::Signed64Array(vec!(1_i64)).is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64)))
+            !VmTerm::Signed64Array(vec!(1_i64)).is_comparable(&VmTerm::Signed64Array(vec!(2_i64, 2_i64)))
         );
         assert!(!VmTerm::Signed128Array(vec!(1_i128))
-            .is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
+            .is_comparable(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
         assert!(!VmTerm::SignedBigArray(vec!(ibig!(1)))
-            .is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
+            .is_comparable(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
 
-        assert!(!VmTerm::Hash160([1; 20]).is_same(&VmTerm::Hash256([2; 32])));
-        assert!(!VmTerm::Hash256([1; 32]).is_same(&VmTerm::Hash512([2; 64])));
-        assert!(!VmTerm::Hash512([1; 64]).is_same(&VmTerm::Hash160([2; 20])));
-        assert!(!VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Unsigned16(2_u16)));
-        assert!(!VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Unsigned32(2_u32)));
-        assert!(!VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Unsigned64(2_u64)));
-        assert!(!VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Unsigned128(2_u128)));
-        assert!(!VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Unsigned8(2_u8)));
-        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
-        assert!(!VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Signed8(2_i8)));
-        assert!(!VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Signed16(2_i16)));
-        assert!(!VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Signed32(2_i32)));
-        assert!(!VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Signed64(2_i64)));
-        assert!(!VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Signed128(2_i128)));
-        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
-        assert!(!VmTerm::Unsigned8(1_u8).is_same(&VmTerm::Signed128(2_i128)));
-        assert!(!VmTerm::Unsigned16(1_u16).is_same(&VmTerm::Signed64(2_i64)));
-        assert!(!VmTerm::Unsigned32(1_u32).is_same(&VmTerm::Signed32(2_i32)));
-        assert!(!VmTerm::Unsigned64(1_u64).is_same(&VmTerm::Signed64(2_i64)));
-        assert!(!VmTerm::Unsigned128(1_u128).is_same(&VmTerm::Signed128(2_i128)));
-        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
+        assert!(!VmTerm::Hash160([1; 20]).is_comparable(&VmTerm::Hash256([2; 32])));
+        assert!(!VmTerm::Hash256([1; 32]).is_comparable(&VmTerm::Hash512([2; 64])));
+        assert!(!VmTerm::Hash512([1; 64]).is_comparable(&VmTerm::Hash160([2; 20])));
+        assert!(!VmTerm::Unsigned8(1_u8).is_comparable(&VmTerm::Unsigned16(2_u16)));
+        assert!(!VmTerm::Unsigned16(1_u16).is_comparable(&VmTerm::Unsigned32(2_u32)));
+        assert!(!VmTerm::Unsigned32(1_u32).is_comparable(&VmTerm::Unsigned64(2_u64)));
+        assert!(!VmTerm::Unsigned64(1_u64).is_comparable(&VmTerm::Unsigned128(2_u128)));
+        assert!(!VmTerm::Unsigned128(1_u128).is_comparable(&VmTerm::Unsigned8(2_u8)));
+        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_comparable(&VmTerm::SignedBig(ibig!(2))));
+        assert!(!VmTerm::Unsigned8(1_u8).is_comparable(&VmTerm::Signed8(2_i8)));
+        assert!(!VmTerm::Unsigned16(1_u16).is_comparable(&VmTerm::Signed16(2_i16)));
+        assert!(!VmTerm::Unsigned32(1_u32).is_comparable(&VmTerm::Signed32(2_i32)));
+        assert!(!VmTerm::Unsigned64(1_u64).is_comparable(&VmTerm::Signed64(2_i64)));
+        assert!(!VmTerm::Unsigned128(1_u128).is_comparable(&VmTerm::Signed128(2_i128)));
+        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_comparable(&VmTerm::SignedBig(ibig!(2))));
+        assert!(!VmTerm::Unsigned8(1_u8).is_comparable(&VmTerm::Signed128(2_i128)));
+        assert!(!VmTerm::Unsigned16(1_u16).is_comparable(&VmTerm::Signed64(2_i64)));
+        assert!(!VmTerm::Unsigned32(1_u32).is_comparable(&VmTerm::Signed32(2_i32)));
+        assert!(!VmTerm::Unsigned64(1_u64).is_comparable(&VmTerm::Signed64(2_i64)));
+        assert!(!VmTerm::Unsigned128(1_u128).is_comparable(&VmTerm::Signed128(2_i128)));
+        assert!(!VmTerm::UnsignedBig(ubig!(1)).is_comparable(&VmTerm::SignedBig(ibig!(2))));
     }
 
     #[test]

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -1232,9 +1232,8 @@ mod tests {
             .is_comparable(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
         assert!(VmTerm::UnsignedBigArray(vec!(ubig!(1), ubig!(1)))
             .is_comparable(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
-        assert!(
-            VmTerm::Signed8Array(vec!(1_i8, 1_i8)).is_comparable(&VmTerm::Signed8Array(vec!(2_i8, 2_i8)))
-        );
+        assert!(VmTerm::Signed8Array(vec!(1_i8, 1_i8))
+            .is_comparable(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
         assert!(VmTerm::Signed16Array(vec!(1_i16, 1_i16))
             .is_comparable(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
         assert!(VmTerm::Signed32Array(vec!(1_i32, 1_i32))
@@ -1252,9 +1251,8 @@ mod tests {
             .is_comparable(&VmTerm::Hash256Array(vec!([2; 32], [2; 32]))));
         assert!(!VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64]))
             .is_comparable(&VmTerm::Hash512Array(vec!([2; 64]))));
-        assert!(
-            !VmTerm::Unsigned8Array(vec!(1_u8)).is_comparable(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8)))
-        );
+        assert!(!VmTerm::Unsigned8Array(vec!(1_u8))
+            .is_comparable(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
         assert!(!VmTerm::Unsigned16Array(vec!(1_u16))
             .is_comparable(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
         assert!(!VmTerm::Unsigned32Array(vec!(1_u32))
@@ -1265,16 +1263,14 @@ mod tests {
             .is_comparable(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
         assert!(!VmTerm::UnsignedBigArray(vec!(ubig!(1)))
             .is_comparable(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
-        assert!(!VmTerm::Signed8Array(vec!(1_i8)).is_comparable(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
-        assert!(
-            !VmTerm::Signed16Array(vec!(1_i16)).is_comparable(&VmTerm::Signed16Array(vec!(2_i16, 2_i16)))
-        );
-        assert!(
-            !VmTerm::Signed32Array(vec!(1_i32)).is_comparable(&VmTerm::Signed32Array(vec!(2_i32, 2_i32)))
-        );
-        assert!(
-            !VmTerm::Signed64Array(vec!(1_i64)).is_comparable(&VmTerm::Signed64Array(vec!(2_i64, 2_i64)))
-        );
+        assert!(!VmTerm::Signed8Array(vec!(1_i8))
+            .is_comparable(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
+        assert!(!VmTerm::Signed16Array(vec!(1_i16))
+            .is_comparable(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
+        assert!(!VmTerm::Signed32Array(vec!(1_i32))
+            .is_comparable(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
+        assert!(!VmTerm::Signed64Array(vec!(1_i64))
+            .is_comparable(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
         assert!(!VmTerm::Signed128Array(vec!(1_i128))
             .is_comparable(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
         assert!(!VmTerm::SignedBigArray(vec!(ibig!(1)))

--- a/src/vm/internal/term.rs
+++ b/src/vm/internal/term.rs
@@ -424,15 +424,19 @@ impl VmTerm {
             (Self::Unsigned16Array(arr1), Self::Unsigned16Array(arr2)) => arr1.len() == arr2.len(),
             (Self::Unsigned32Array(arr1), Self::Unsigned32Array(arr2)) => arr1.len() == arr2.len(),
             (Self::Unsigned64Array(arr1), Self::Unsigned64Array(arr2)) => arr1.len() == arr2.len(),
-            (Self::Unsigned128Array(arr1), Self::Unsigned128Array(arr2)) => arr1.len() == arr2.len(),
-            (Self::UnsignedBigArray(arr1), Self::UnsignedBigArray(arr2)) => arr1.len() == arr2.len(),
+            (Self::Unsigned128Array(arr1), Self::Unsigned128Array(arr2)) => {
+                arr1.len() == arr2.len()
+            }
+            (Self::UnsignedBigArray(arr1), Self::UnsignedBigArray(arr2)) => {
+                arr1.len() == arr2.len()
+            }
             (Self::Signed8Array(arr1), Self::Signed8Array(arr2)) => arr1.len() == arr2.len(),
             (Self::Signed16Array(arr1), Self::Signed16Array(arr2)) => arr1.len() == arr2.len(),
             (Self::Signed32Array(arr1), Self::Signed32Array(arr2)) => arr1.len() == arr2.len(),
             (Self::Signed64Array(arr1), Self::Signed64Array(arr2)) => arr1.len() == arr2.len(),
             (Self::Signed128Array(arr1), Self::Signed128Array(arr2)) => arr1.len() == arr2.len(),
             (Self::SignedBigArray(arr1), Self::SignedBigArray(arr2)) => arr1.len() == arr2.len(),
-            _ => false
+            _ => false,
         }
     }
 
@@ -490,7 +494,7 @@ impl VmTerm {
             Self::Signed64Array(arr) => arr.len(),
             Self::Signed128Array(arr) => arr.len(),
             Self::SignedBigArray(arr) => arr.len(),
-            _ => 0
+            _ => 0,
         }
     }
 }
@@ -1210,37 +1214,71 @@ mod tests {
         assert!(VmTerm::Signed128(1_i128).is_same(&VmTerm::Signed128(2_i128)));
         assert!(VmTerm::SignedBig(ibig!(1)).is_same(&VmTerm::SignedBig(ibig!(2))));
 
-        assert!(VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20])).is_same(&VmTerm::Hash160Array(vec!([2; 20], [2; 20], [2; 20]))));
-        assert!(VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32])).is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32], [2; 32]))));
-        assert!(VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64])).is_same(&VmTerm::Hash512Array(vec!([2; 64], [2; 64], [2; 64]))));
-        assert!(VmTerm::Unsigned8Array(vec!(1_u8, 1_u8)).is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
-        assert!(VmTerm::Unsigned16Array(vec!(1_u16, 1_u16)).is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
-        assert!(VmTerm::Unsigned32Array(vec!(1_u32, 1_u32)).is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
-        assert!(VmTerm::Unsigned64Array(vec!(1_u64, 1_u64)).is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
-        assert!(VmTerm::Unsigned128Array(vec!(1_u128, 1_u128)).is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
-        assert!(VmTerm::UnsignedBigArray(vec!(ubig!(1), ubig!(1))).is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
-        assert!(VmTerm::Signed8Array(vec!(1_i8, 1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
-        assert!(VmTerm::Signed16Array(vec!(1_i16, 1_i16)).is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
-        assert!(VmTerm::Signed32Array(vec!(1_i32, 1_i32)).is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
-        assert!(VmTerm::Signed64Array(vec!(1_i64, 1_i64)).is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
-        assert!(VmTerm::Signed128Array(vec!(1_i128, 1_i128)).is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
-        assert!(VmTerm::SignedBigArray(vec!(ibig!(1), ibig!(1))).is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
+        assert!(VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20]))
+            .is_same(&VmTerm::Hash160Array(vec!([2; 20], [2; 20], [2; 20]))));
+        assert!(VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32]))
+            .is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32], [2; 32]))));
+        assert!(VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64]))
+            .is_same(&VmTerm::Hash512Array(vec!([2; 64], [2; 64], [2; 64]))));
+        assert!(VmTerm::Unsigned8Array(vec!(1_u8, 1_u8))
+            .is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
+        assert!(VmTerm::Unsigned16Array(vec!(1_u16, 1_u16))
+            .is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
+        assert!(VmTerm::Unsigned32Array(vec!(1_u32, 1_u32))
+            .is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
+        assert!(VmTerm::Unsigned64Array(vec!(1_u64, 1_u64))
+            .is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
+        assert!(VmTerm::Unsigned128Array(vec!(1_u128, 1_u128))
+            .is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
+        assert!(VmTerm::UnsignedBigArray(vec!(ubig!(1), ubig!(1)))
+            .is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
+        assert!(
+            VmTerm::Signed8Array(vec!(1_i8, 1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8)))
+        );
+        assert!(VmTerm::Signed16Array(vec!(1_i16, 1_i16))
+            .is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
+        assert!(VmTerm::Signed32Array(vec!(1_i32, 1_i32))
+            .is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
+        assert!(VmTerm::Signed64Array(vec!(1_i64, 1_i64))
+            .is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
+        assert!(VmTerm::Signed128Array(vec!(1_i128, 1_i128))
+            .is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
+        assert!(VmTerm::SignedBigArray(vec!(ibig!(1), ibig!(1)))
+            .is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
 
-        assert!(!VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20])).is_same(&VmTerm::Hash160Array(vec!([2; 20]))));
-        assert!(!VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32])).is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32]))));
-        assert!(!VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64])).is_same(&VmTerm::Hash512Array(vec!([2; 64]))));
-        assert!(!VmTerm::Unsigned8Array(vec!(1_u8)).is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8))));
-        assert!(!VmTerm::Unsigned16Array(vec!(1_u16)).is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
-        assert!(!VmTerm::Unsigned32Array(vec!(1_u32)).is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
-        assert!(!VmTerm::Unsigned64Array(vec!(1_u64)).is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
-        assert!(!VmTerm::Unsigned128Array(vec!( 1_u128)).is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
-        assert!(!VmTerm::UnsignedBigArray(vec!(ubig!(1))).is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
+        assert!(!VmTerm::Hash160Array(vec!([1; 20], [1; 20], [1; 20]))
+            .is_same(&VmTerm::Hash160Array(vec!([2; 20]))));
+        assert!(!VmTerm::Hash256Array(vec!([1; 32], [1; 32], [1; 32]))
+            .is_same(&VmTerm::Hash256Array(vec!([2; 32], [2; 32]))));
+        assert!(!VmTerm::Hash512Array(vec!([1; 64], [1; 64], [1; 64]))
+            .is_same(&VmTerm::Hash512Array(vec!([2; 64]))));
+        assert!(
+            !VmTerm::Unsigned8Array(vec!(1_u8)).is_same(&VmTerm::Unsigned8Array(vec!(2_u8, 2_u8)))
+        );
+        assert!(!VmTerm::Unsigned16Array(vec!(1_u16))
+            .is_same(&VmTerm::Unsigned16Array(vec!(2_u16, 2_u16))));
+        assert!(!VmTerm::Unsigned32Array(vec!(1_u32))
+            .is_same(&VmTerm::Unsigned32Array(vec!(2_u32, 2_u32))));
+        assert!(!VmTerm::Unsigned64Array(vec!(1_u64))
+            .is_same(&VmTerm::Unsigned64Array(vec!(2_u64, 2_u64))));
+        assert!(!VmTerm::Unsigned128Array(vec!(1_u128))
+            .is_same(&VmTerm::Unsigned128Array(vec!(2_u128, 2_u128))));
+        assert!(!VmTerm::UnsignedBigArray(vec!(ubig!(1)))
+            .is_same(&VmTerm::UnsignedBigArray(vec!(ubig!(2), ubig!(2)))));
         assert!(!VmTerm::Signed8Array(vec!(1_i8)).is_same(&VmTerm::Signed8Array(vec!(2_i8, 2_i8))));
-        assert!(!VmTerm::Signed16Array(vec!(1_i16)).is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16))));
-        assert!(!VmTerm::Signed32Array(vec!(1_i32)).is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32))));
-        assert!(!VmTerm::Signed64Array(vec!(1_i64)).is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64))));
-        assert!(!VmTerm::Signed128Array(vec!(1_i128)).is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
-        assert!(!VmTerm::SignedBigArray(vec!(ibig!(1))).is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
+        assert!(
+            !VmTerm::Signed16Array(vec!(1_i16)).is_same(&VmTerm::Signed16Array(vec!(2_i16, 2_i16)))
+        );
+        assert!(
+            !VmTerm::Signed32Array(vec!(1_i32)).is_same(&VmTerm::Signed32Array(vec!(2_i32, 2_i32)))
+        );
+        assert!(
+            !VmTerm::Signed64Array(vec!(1_i64)).is_same(&VmTerm::Signed64Array(vec!(2_i64, 2_i64)))
+        );
+        assert!(!VmTerm::Signed128Array(vec!(1_i128))
+            .is_same(&VmTerm::Signed128Array(vec!(2_i128, 2_i128))));
+        assert!(!VmTerm::SignedBigArray(vec!(ibig!(1)))
+            .is_same(&VmTerm::SignedBigArray(vec!(ibig!(2), ibig!(2)))));
 
         assert!(!VmTerm::Hash160([1; 20]).is_same(&VmTerm::Hash256([2; 32])));
         assert!(!VmTerm::Hash256([1; 32]).is_same(&VmTerm::Hash512([2; 64])));

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -1571,7 +1571,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1598,7 +1598,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1625,7 +1625,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1652,7 +1652,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1679,7 +1679,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1706,7 +1706,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1775,7 +1775,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1804,7 +1804,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1833,7 +1833,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1862,7 +1862,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1891,7 +1891,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -1920,7 +1920,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -2492,7 +2492,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -2523,7 +2523,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -2554,7 +2554,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
@@ -2585,7 +2585,7 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
-                    if !e1.is_same(&e2) {
+                    if !e1.is_comparable(&e2) {
                         self.state = ScriptExecutorState::Error(
                             ExecutionResult::InvalidArgs,
                             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -2478,6 +2478,130 @@ impl<'a> ScriptExecutor<'a> {
                     self.state = ScriptExecutorState::ExpectingIndexU8(OP::PickToScriptOuts);
                 }
 
+                ScriptEntry::Opcode(OP::Lt) => {
+                    if exec_stack.len() < 2 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let e1 = exec_stack.pop().unwrap();
+                    *memory_size -= e1.size();
+                    let e2 = exec_stack.pop().unwrap();
+                    *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    if e1 < e2 {
+                        exec_stack.push(VmTerm::Unsigned8(1));
+                        *memory_size += 1;
+                    } else {
+                        exec_stack.push(VmTerm::Unsigned8(0));
+                        *memory_size += 1;
+                    }
+                }
+
+                ScriptEntry::Opcode(OP::Gt) => {
+                    if exec_stack.len() < 2 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let e1 = exec_stack.pop().unwrap();
+                    *memory_size -= e1.size();
+                    let e2 = exec_stack.pop().unwrap();
+                    *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    if e1 > e2 {
+                        exec_stack.push(VmTerm::Unsigned8(1));
+                        *memory_size += 1;
+                    } else {
+                        exec_stack.push(VmTerm::Unsigned8(0));
+                        *memory_size += 1;
+                    }
+                }
+
+                ScriptEntry::Opcode(OP::Leq) => {
+                    if exec_stack.len() < 2 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let e1 = exec_stack.pop().unwrap();
+                    *memory_size -= e1.size();
+                    let e2 = exec_stack.pop().unwrap();
+                    *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    if e1 <= e2 {
+                        exec_stack.push(VmTerm::Unsigned8(1));
+                        *memory_size += 1;
+                    } else {
+                        exec_stack.push(VmTerm::Unsigned8(0));
+                        *memory_size += 1;
+                    }
+                }
+
+                ScriptEntry::Opcode(OP::Geq) => {
+                    if exec_stack.len() < 2 {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    let e1 = exec_stack.pop().unwrap();
+                    *memory_size -= e1.size();
+                    let e2 = exec_stack.pop().unwrap();
+                    *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
+                    if e1 >= e2 {
+                        exec_stack.push(VmTerm::Unsigned8(1));
+                        *memory_size += 1;
+                    } else {
+                        exec_stack.push(VmTerm::Unsigned8(0));
+                        *memory_size += 1;
+                    }
+                }
+
                 ScriptEntry::Opcode(OP::GetType) => {
                     if exec_stack.is_empty() {
                         self.state = ScriptExecutorState::Error(
@@ -8398,6 +8522,266 @@ mod tests {
                 &mut outs,
                 &mut idx_map,
                 seed,
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_pushes_1_if_lt_and_0_if_not() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Opcode(OP::Lt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Lt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x10),
+                ScriptEntry::Opcode(OP::Lt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x10),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Lt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x00),
+            VmTerm::Unsigned8(0x00),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_pushes_1_if_gt_and_0_if_not() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Opcode(OP::Gt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Gt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x10),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Gt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x10),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Gt),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x00),
+            VmTerm::Unsigned8(0x00),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_pushes_1_if_leq_and_0_if_not() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Opcode(OP::Leq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x08),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Leq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Leq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Leq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x00),
+            VmTerm::Unsigned8(0x00),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
+                key,
+                VmFlags::default()
+            ),
+            Ok(ExecutionResult::OkVerify).into()
+        );
+        assert_eq!(outs, base.out);
+    }
+
+    #[test]
+    fn it_pushes_1_if_geq_and_0_if_not() {
+        let key = "test_key";
+        let ss = Script {
+            version: 1,
+            script: vec![
+                ScriptEntry::Byte(0x03), // 3 arguments are pushed onto the stack: out_amount, out_address, out_script_hash
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Opcode(OP::Geq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x09),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Geq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Opcode(OP::Unsigned8Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Opcode(OP::Geq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x02),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Unsigned16Var),
+                ScriptEntry::Byte(0x01),
+                ScriptEntry::Byte(0x00),
+                ScriptEntry::Opcode(OP::Geq),
+                ScriptEntry::Opcode(OP::PopToScriptOuts),
+                ScriptEntry::Opcode(OP::PushOut),
+                ScriptEntry::Opcode(OP::Verify),
+            ],
+        };
+
+        let script_output: Vec<VmTerm> = vec![
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x01),
+            VmTerm::Unsigned8(0x00),
+            VmTerm::Unsigned8(0x00),
+        ];
+        let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
+        let mut idx_map = HashMap::new();
+        let mut outs = vec![];
+
+        assert_eq!(
+            ss.execute(
+                &base.args,
+                &base.ins,
+                &mut outs,
+                &mut idx_map,
+                [0; 32],
                 key,
                 VmFlags::default()
             ),

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -1571,6 +1571,14 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
                     if e1 == e2 {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
@@ -1589,6 +1597,14 @@ impl<'a> ScriptExecutor<'a> {
                     *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
 
                     if e1 != e2 {
                         self.state = ScriptExecutorState::BreakLoop;
@@ -1609,6 +1625,14 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
                     if e1 <= e2 {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
@@ -1627,6 +1651,14 @@ impl<'a> ScriptExecutor<'a> {
                     *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
 
                     if e1 >= e2 {
                         self.state = ScriptExecutorState::BreakLoop;
@@ -1647,6 +1679,14 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
                     if e1 < e2 {
                         self.state = ScriptExecutorState::BreakLoop;
                     }
@@ -1665,6 +1705,14 @@ impl<'a> ScriptExecutor<'a> {
                     *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
 
                     if e1 > e2 {
                         self.state = ScriptExecutorState::BreakLoop;
@@ -1727,6 +1775,14 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
                     if e1 == e2 {
                         self.state = ScriptExecutorState::ContinueLoop;
                     } else {
@@ -1747,6 +1803,14 @@ impl<'a> ScriptExecutor<'a> {
                     *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
 
                     if e1 != e2 {
                         self.state = ScriptExecutorState::ContinueLoop;
@@ -1769,6 +1833,14 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
                     if e1 <= e2 {
                         self.state = ScriptExecutorState::ContinueLoop;
                     } else {
@@ -1789,6 +1861,14 @@ impl<'a> ScriptExecutor<'a> {
                     *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
 
                     if e1 >= e2 {
                         self.state = ScriptExecutorState::ContinueLoop;
@@ -1811,6 +1891,14 @@ impl<'a> ScriptExecutor<'a> {
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
 
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
+
                     if e1 < e2 {
                         self.state = ScriptExecutorState::ContinueLoop;
                     } else {
@@ -1831,6 +1919,14 @@ impl<'a> ScriptExecutor<'a> {
                     *memory_size -= e1.size();
                     let e2 = exec_stack.pop().unwrap();
                     *memory_size -= e2.size();
+
+                    if !e1.is_same(&e2) {
+                        self.state = ScriptExecutorState::Error(
+                            ExecutionResult::InvalidArgs,
+                            (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                        );
+                        return;
+                    }
 
                     if e1 > e2 {
                         self.state = ScriptExecutorState::ContinueLoop;
@@ -2300,6 +2396,31 @@ impl<'a> ScriptExecutor<'a> {
                     self.state =
                         ScriptExecutorState::ExpectingBytesOrCachedTerm(OP::SignedBigArrayVar);
                 }
+
+                // ScriptEntry::Opcode(OP::ArrayLen) => {
+                //     if exec_stack.is_empty() {
+                //         self.state = ScriptExecutorState::Error(
+                //             ExecutionResult::InvalidArgs,
+                //             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                //         );
+                //         return;
+                //     }
+
+                //     let mut last = exec_stack.last_mut().unwrap();
+
+                //     if !last.is_array() {
+                //         self.state = ScriptExecutorState::Error(
+                //             ExecutionResult::InvalidArgs,
+                //             (i_ptr, func_idx, op.clone(), exec_stack.as_slice()).into(),
+                //         );
+                //         return;
+                //     }
+
+                //     let e = VmTerm::Unsigned16(last --> len as u64);
+
+                //     *memory_size += e.size();
+                //     exec_stack.push(e);
+                // }
 
                 ScriptEntry::Opcode(OP::Add1) => {
                     if exec_stack.is_empty() {

--- a/src/vm/script.rs
+++ b/src/vm/script.rs
@@ -7853,10 +7853,8 @@ mod tests {
             ],
         };
 
-        let script_output: Vec<VmTerm> = vec![
-            VmTerm::Unsigned16(0x0004),
-            VmTerm::Unsigned16(0x0006),
-        ];
+        let script_output: Vec<VmTerm> =
+            vec![VmTerm::Unsigned16(0x0004), VmTerm::Unsigned16(0x0006)];
         let base: TestBaseArgs = get_test_base_args(&ss, 30, script_output, 0, key);
         let mut idx_map = HashMap::new();
         let mut outs = vec![];


### PR DESCRIPTION
PR containing comparison fixes and OpCodes.

We have to make sure the term types are validated before comparison otherwise the operations will succeed wrongly.