### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ cargo-features = ["profile-rustflags"]
 name = "purplecoin"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/purpleprotocol/purplecoin"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link to it